### PR TITLE
feat: Add ThreePillars (三柱) system

### DIFF
--- a/Sources/tyme/sixtycycle/SixtyCycleDay.swift
+++ b/Sources/tyme/sixtycycle/SixtyCycleDay.swift
@@ -110,4 +110,50 @@ public final class SixtyCycleDay: AbstractCulture {
     public static func fromYmd(_ year: Int, _ month: Int, _ day: Int) -> SixtyCycleDay {
         return SixtyCycleDay(year: year, month: month, day: day)
     }
+
+    /// 三柱（年柱、月柱、日柱）
+    public func getThreePillars() -> ThreePillars {
+        let term = findPrevailingTerm()
+        let termIndex = term.getIndex()
+        let termYear = term.getYear()
+
+        // 月柱距寅月的偏移
+        let offset: Int
+        if termIndex < 3 {
+            offset = termIndex == 0 ? -2 : -1
+        } else {
+            offset = (termIndex - 3) / 2
+        }
+
+        // 干支年（立春换年）
+        let cycleYear = offset < 0 ? termYear - 1 : termYear
+        let yearSixtyCycle = SixtyCycle.fromIndex(cycleYear - 4)
+
+        // 月干支（五虎遁）
+        let yearHeavenStemIndex = yearSixtyCycle.getHeavenStem().getIndex()
+        let firstMonthHeavenStemIndex = (yearHeavenStemIndex + 1) * 2
+        let normalizedOffset = offset < 0 ? offset + 12 : offset
+        let monthHeavenStemIndex = (firstMonthHeavenStemIndex + normalizedOffset) % 10
+        let monthEarthBranchIndex = (2 + normalizedOffset) % 12
+        let monthName = HeavenStem.NAMES[monthHeavenStemIndex] + EarthBranch.NAMES[monthEarthBranchIndex]
+        let monthSixtyCycle = SixtyCycle.fromName(monthName)
+
+        return ThreePillars(year: yearSixtyCycle, month: monthSixtyCycle, day: sixtyCycle)
+    }
+
+    private func findPrevailingTerm() -> SolarTerm {
+        var y = solarDay.getYear()
+        var i = solarDay.getMonth() * 2
+        if i == 24 {
+            y += 1
+            i = 0
+        }
+        var term = SolarTerm.fromIndex(y, i + 1)
+        var termDay = term.getSolarDay()
+        while solarDay.isBefore(termDay) {
+            term = term.next(-1)
+            termDay = term.getSolarDay()
+        }
+        return term
+    }
 }

--- a/Sources/tyme/sixtycycle/ThreePillars.swift
+++ b/Sources/tyme/sixtycycle/ThreePillars.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// 三柱（年柱、月柱、日柱）
+public final class ThreePillars: AbstractCulture {
+    private let year: SixtyCycle
+    private let month: SixtyCycle
+    private let day: SixtyCycle
+
+    public init(year: SixtyCycle, month: SixtyCycle, day: SixtyCycle) {
+        self.year = year
+        self.month = month
+        self.day = day
+        super.init()
+    }
+
+    public convenience init(yearName: String, monthName: String, dayName: String) {
+        self.init(
+            year: SixtyCycle.fromName(yearName),
+            month: SixtyCycle.fromName(monthName),
+            day: SixtyCycle.fromName(dayName)
+        )
+    }
+
+    public func getYear() -> SixtyCycle { year }
+    public func getMonth() -> SixtyCycle { month }
+    public func getDay() -> SixtyCycle { day }
+
+    /// 公历日列表
+    /// - Parameters:
+    ///   - startYear: 开始年(含)，支持1-9999年
+    ///   - endYear: 结束年(含)，支持1-9999年
+    /// - Returns: 公历日列表
+    public func getSolarDays(startYear: Int, endYear: Int) -> [SolarDay] {
+        var l: [SolarDay] = []
+        // 月地支距寅月的偏移值
+        var m = month.getEarthBranch().next(-2).getIndex()
+        // 月天干要一致
+        if HeavenStem.fromIndex((year.getHeavenStem().getIndex() + 1) * 2 + m).getName() != month.getHeavenStem().getName() {
+            return l
+        }
+        // 1年的立春是辛酉，序号57
+        var y = year.next(-57).getIndex() + 1
+        // 节令偏移值
+        m *= 2
+        let baseYear = startYear - 1
+        if baseYear > y {
+            y += 60 * Int(ceil(Double(baseYear - y) / 60.0))
+        }
+        while y <= endYear {
+            // 立春为寅月的开始
+            var term = SolarTerm.fromIndex(y, 3)
+            // 节令推移，年干支和月干支就都匹配上了
+            if m > 0 {
+                term = term.next(m)
+            }
+            var solarDay = term.getSolarDay()
+            if solarDay.getYear() >= startYear {
+                // 日干支和节令干支的偏移值
+                let d = day.next(-solarDay.getLunarDay().getSixtyCycle().getIndex()).getIndex()
+                if d > 0 {
+                    // 从节令推移天数
+                    solarDay = solarDay.next(d)
+                }
+                // 验证一下
+                if solarDay.getSixtyCycleDay().getThreePillars().getName() == getName() {
+                    l.append(solarDay)
+                }
+            }
+            y += 60
+        }
+        return l
+    }
+
+    public override func getName() -> String {
+        "\(year) \(month) \(day)"
+    }
+}

--- a/Sources/tyme/solar/SolarDay.swift
+++ b/Sources/tyme/solar/SolarDay.swift
@@ -53,6 +53,10 @@ public final class SolarDay: DayUnit, Tyme {
         return SolarWeek(year: getYear(), month: getMonth(), index: index, start: start)
     }
 
+    public func getSixtyCycleDay() -> SixtyCycleDay {
+        SixtyCycleDay(solarDay: self)
+    }
+
     public func getLunarDay() -> LunarDay {
         var m = LunarMonth.fromYm(getYear(), getMonth())
         var days = subtract(m.getFirstJulianDay().getSolarDay())

--- a/Tests/tymeTests/Tyme4SwiftTests.swift
+++ b/Tests/tymeTests/Tyme4SwiftTests.swift
@@ -1582,5 +1582,65 @@ final class Tyme4SwiftTests: XCTestCase {
         XCTAssertEqual(info.getHeavenStem().getName(), "甲")
         XCTAssertEqual(info.getEarthBranch().getName(), "子")
     }
+
+    // MARK: - ThreePillars Tests
+
+    func testThreePillars() throws {
+        // Test basic creation with SixtyCycle objects
+        let year = SixtyCycle.fromName("甲戌")
+        let month = SixtyCycle.fromName("甲戌")
+        let day = SixtyCycle.fromName("甲戌")
+        let threePillars = ThreePillars(year: year, month: month, day: day)
+
+        XCTAssertEqual(threePillars.getName(), "甲戌 甲戌 甲戌")
+        XCTAssertEqual(threePillars.getYear().getName(), "甲戌")
+        XCTAssertEqual(threePillars.getMonth().getName(), "甲戌")
+        XCTAssertEqual(threePillars.getDay().getName(), "甲戌")
+
+        // Test convenience initializer with strings
+        let threePillars2 = ThreePillars(yearName: "甲戌", monthName: "甲戌", dayName: "甲戌")
+        XCTAssertEqual(threePillars2.getName(), "甲戌 甲戌 甲戌")
+
+        // Test description (CustomStringConvertible)
+        XCTAssertEqual(String(describing: threePillars), "甲戌 甲戌 甲戌")
+    }
+
+    func testThreePillarsFromSolarDay() throws {
+        // Aligned with tyme4j: SolarDay(1034, 10, 2) → ThreePillars = "甲戌 甲戌 甲戌"
+        let solarDay = SolarDay.fromYmd(1034, 10, 2)
+        let threePillars = solarDay.getSixtyCycleDay().getThreePillars()
+        XCTAssertEqual(threePillars.getName(), "甲戌 甲戌 甲戌")
+    }
+
+    func testThreePillarsFromMultipleDates() throws {
+        // Test additional dates to verify getThreePillars consistency
+        // 2024-02-10 should produce a valid ThreePillars
+        let day1 = SolarDay.fromYmd(2024, 2, 10).getSixtyCycleDay()
+        let tp1 = day1.getThreePillars()
+        XCTAssertFalse(tp1.getName().isEmpty)
+        XCTAssertEqual(tp1.getYear().getName().count, 2)
+        XCTAssertEqual(tp1.getMonth().getName().count, 2)
+        XCTAssertEqual(tp1.getDay().getName().count, 2)
+
+        // Verify getName format: "XX XX XX"
+        let parts = tp1.getName().split(separator: " ")
+        XCTAssertEqual(parts.count, 3)
+
+        // Two consecutive days should have different day pillars but same year/month pillars (usually)
+        let day2 = SolarDay.fromYmd(2024, 2, 11).getSixtyCycleDay()
+        let tp2 = day2.getThreePillars()
+        XCTAssertNotEqual(tp1.getDay().getName(), tp2.getDay().getName())
+    }
+
+    func testThreePillarsGetSolarDays() throws {
+        // NOTE: getSolarDays crashes on certain year ranges due to a pre-existing
+        // SolarDay.getLunarDay() bug that produces invalid lunar day values.
+        // This test validates the month-stem check (invalid combinations return empty).
+        // When month heaven stem doesn't match year stem rule, getSolarDays returns empty
+        // without needing to call getLunarDay(), so no crash.
+        let threePillars = ThreePillars(yearName: "甲子", monthName: "甲子", dayName: "甲子")
+        let solarDays = threePillars.getSolarDays(startYear: 1900, endYear: 2200)
+        XCTAssertEqual(solarDays.count, 0)
+    }
 }
 


### PR DESCRIPTION
## Summary
- Add `ThreePillars.swift` — year/month/day pillar combination class (继承 AbstractCulture)
- Add `getThreePillars()` method to `SixtyCycleDay`
- Add `getSixtyCycleDay()` method to `SolarDay`
- Add 4 test cases (78 total, all passing)

Closes #5

## Test plan
- [x] `swift build` passes
- [x] `swift test` — 78 tests, 0 failures
- [x] Basic creation and property access
- [x] SolarDay → getThreePillars() reverse lookup (tyme4j aligned)
- [x] Invalid pillar combination returns empty array
- [ ] `getSolarDays()` full range test blocked by pre-existing `SolarDay.getLunarDay()` bug (tracked separately)

## Known Issue
`getSolarDays(startYear:1, endYear:2200)` crashes on some dates due to a pre-existing bug in `SolarDay.getLunarDay()` → `LunarDay.fromYmd()` (Invalid day overflow). This is NOT a ThreePillars implementation issue — recommend tracking separately.