### PR TITLE
feat: Add ChildLimit provider variants (LunarSect1/Sect2/China95)

### DIFF
--- a/Sources/tyme/eightchar/provider/ChildLimitProvider.swift
+++ b/Sources/tyme/eightchar/provider/ChildLimitProvider.swift
@@ -1,40 +1,62 @@
 import Foundation
 
 /// 童限计算提供者协议 (ChildLimit Provider Protocol)
-/// Protocol for different ChildLimit calculation methods
 public protocol ChildLimitProvider {
-    /// Calculate child limit info
-    /// - Parameters:
-    ///   - gender: Gender (male/female)
-    ///   - year: Birth year
-    ///   - month: Birth month
-    ///   - day: Birth day
-    ///   - hour: Birth hour
-    /// - Returns: ChildLimitInfo with years, months, days
-    func getChildLimit(gender: Gender, year: Int, month: Int, day: Int, hour: Int) -> ChildLimitInfo
+    func getInfo(birthTime: SolarTime, term: SolarTerm) -> ChildLimitInfo
+}
+
+/// 童限计算抽象辅助方法
+extension ChildLimitProvider {
+    func next(_ birthTime: SolarTime, _ addYear: Int, _ addMonth: Int, _ addDay: Int, _ addHour: Int, _ addMinute: Int, _ addSecond: Int) -> ChildLimitInfo {
+        var d = birthTime.getDay() + addDay
+        var h = birthTime.getHour() + addHour
+        var mi = birthTime.getMinute() + addMinute
+        var s = birthTime.getSecond() + addSecond
+        mi += s / 60
+        s = s % 60
+        h += mi / 60
+        mi = mi % 60
+        d += h / 24
+        h = h % 24
+
+        var sm = SolarMonth.fromYm(birthTime.getYear() + addYear, birthTime.getMonth()).next(addMonth)
+
+        var dc = sm.getDayCount()
+        while d > dc {
+            d -= dc
+            sm = sm.next(1)
+            dc = sm.getDayCount()
+        }
+
+        return ChildLimitInfo(
+            startTime: birthTime,
+            endTime: SolarTime.fromYmdHms(sm.getYear(), sm.getMonth(), d, h, mi, s),
+            yearCount: addYear,
+            monthCount: addMonth,
+            dayCount: addDay,
+            hourCount: addHour,
+            minuteCount: addMinute
+        )
+    }
 }
 
 /// 童限信息 (ChildLimit Info)
-/// Contains the calculated child limit period
 public struct ChildLimitInfo {
-    public let years: Int
-    public let months: Int
-    public let days: Int
-    public let startYear: Int
-    public let startMonth: Int
-    public let startDay: Int
+    public let startTime: SolarTime
+    public let endTime: SolarTime
+    public let yearCount: Int
+    public let monthCount: Int
+    public let dayCount: Int
+    public let hourCount: Int
+    public let minuteCount: Int
 
-    public init(years: Int, months: Int, days: Int, startYear: Int, startMonth: Int, startDay: Int) {
-        self.years = years
-        self.months = months
-        self.days = days
-        self.startYear = startYear
-        self.startMonth = startMonth
-        self.startDay = startDay
-    }
-
-    /// Get total days
-    public func getTotalDays() -> Int {
-        return years * 365 + months * 30 + days
+    public init(startTime: SolarTime, endTime: SolarTime, yearCount: Int, monthCount: Int, dayCount: Int, hourCount: Int, minuteCount: Int) {
+        self.startTime = startTime
+        self.endTime = endTime
+        self.yearCount = yearCount
+        self.monthCount = monthCount
+        self.dayCount = dayCount
+        self.hourCount = hourCount
+        self.minuteCount = minuteCount
     }
 }

--- a/Sources/tyme/eightchar/provider/China95ChildLimitProvider.swift
+++ b/Sources/tyme/eightchar/provider/China95ChildLimitProvider.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// 元亨利贞童限计算
+public final class China95ChildLimitProvider: ChildLimitProvider {
+    public init() {}
+
+    public func getInfo(birthTime: SolarTime, term: SolarTerm) -> ChildLimitInfo {
+        // 出生时刻和节令时刻相差的分钟数
+        var minutes = abs(term.getJulianDay().getSolarTime().subtract(birthTime)) / 60
+        let year = minutes / 4320
+        minutes %= 4320
+        let month = minutes / 360
+        minutes %= 360
+        let day = minutes / 12
+
+        return next(birthTime, year, month, day, 0, 0, 0)
+    }
+}

--- a/Sources/tyme/eightchar/provider/DefaultChildLimitProvider.swift
+++ b/Sources/tyme/eightchar/provider/DefaultChildLimitProvider.swift
@@ -1,68 +1,27 @@
 import Foundation
 
-/// 默认童限计算提供者 (Default ChildLimit Provider)
-/// Standard calculation method for ChildLimit
+/// 默认童限计算（按秒数计算）
 public final class DefaultChildLimitProvider: ChildLimitProvider {
     public init() {}
 
-    /// Calculate child limit info
-    /// Based on the distance to the nearest solar term
-    public func getChildLimit(gender: Gender, year: Int, month: Int, day: Int, hour: Int) -> ChildLimitInfo {
-        // Get the year pillar to determine direction
-        let provider = DefaultEightCharProvider()
-        let yearSixtyCycle = provider.getYearSixtyCycle(year: year, month: month, day: day)
-        let yearStemIndex = yearSixtyCycle.getHeavenStem().getIndex()
+    public func getInfo(birthTime: SolarTime, term: SolarTerm) -> ChildLimitInfo {
+        // 出生时刻和节令时刻相差的秒数
+        var seconds = abs(term.getJulianDay().getSolarTime().subtract(birthTime))
+        // 3天=259200秒=1年
+        let year = seconds / 259200
+        seconds %= 259200
+        // 1天=86400秒=4月，21600秒=1月
+        let month = seconds / 21600
+        seconds %= 21600
+        // 1时=3600秒=5天，720秒=1天
+        let day = seconds / 720
+        seconds %= 720
+        // 1分=60秒=2时，30秒=1时
+        let hour = seconds / 30
+        seconds %= 30
+        // 1秒=2分
+        let minute = seconds * 2
 
-        // Determine direction: Yang year + Male or Yin year + Female = forward
-        let isYangYear = yearStemIndex % 2 == 0
-        let isMale = gender.isMale
-        let isForward = (isYangYear && isMale) || (!isYangYear && !isMale)
-
-        // Find the nearest solar term
-        let solarDay = SolarDay.fromYmd(year, month, day)
-        _ = solarDay.getJulianDay()
-
-        // Get current solar term index
-        var termIndex = (month - 1) * 2
-        if isForward {
-            // Find next Jie (节)
-            termIndex = termIndex + 3 // Next Jie
-            if termIndex >= 24 { termIndex -= 24 }
-        } else {
-            // Find previous Jie (节)
-            termIndex = termIndex + 1 // Previous Jie
-            if termIndex < 0 { termIndex += 24 }
-        }
-
-        // Get the target solar term
-        let targetYear = isForward ? year : (termIndex > (month - 1) * 2 ? year - 1 : year)
-        let targetTerm = SolarTerm.fromIndex(targetYear, termIndex)
-        let targetDay = targetTerm.getSolarDay()
-
-        // Calculate days difference
-        var daysDiff = abs(solarDay.subtract(targetDay))
-
-        // Convert to years, months, days (3 days = 1 year)
-        let years = daysDiff / 3
-        daysDiff = daysDiff % 3
-        let months = daysDiff * 4  // Each day = 4 months
-        let days = 0
-
-        // Calculate start date
-        let startYear = year + years
-        var startMonth = month + months
-        let startDay = day
-        while startMonth > 12 {
-            startMonth -= 12
-        }
-
-        return ChildLimitInfo(
-            years: years,
-            months: months,
-            days: days,
-            startYear: startYear,
-            startMonth: startMonth,
-            startDay: startDay
-        )
+        return next(birthTime, year, month, day, hour, minute, 0)
     }
 }

--- a/Sources/tyme/eightchar/provider/DefaultDecadeFortuneProvider.swift
+++ b/Sources/tyme/eightchar/provider/DefaultDecadeFortuneProvider.swift
@@ -1,27 +1,23 @@
 import Foundation
 
 /// 默认大运计算提供者 (Default DecadeFortune Provider)
-/// Standard calculation method for DecadeFortune
 public final class DefaultDecadeFortuneProvider: DecadeFortuneProvider {
     public init() {}
 
-    /// Get decade fortunes
     public func getDecadeFortunes(gender: Gender, year: Int, month: Int, day: Int, hour: Int, count: Int) -> [DecadeFortuneInfo] {
-        // Get the month pillar as starting point
         let provider = DefaultEightCharProvider()
         let yearSixtyCycle = provider.getYearSixtyCycle(year: year, month: month, day: day)
         let monthSixtyCycle = provider.getMonthSixtyCycle(year: year, month: month, day: day)
 
-        // Determine direction
         let yearStemIndex = yearSixtyCycle.getHeavenStem().getIndex()
         let isYangYear = yearStemIndex % 2 == 0
         let isMale = gender.isMale
         let isForward = (isYangYear && isMale) || (!isYangYear && !isMale)
 
-        // Get child limit to determine start age
-        let childLimitProvider = DefaultChildLimitProvider()
-        let childLimit = childLimitProvider.getChildLimit(gender: gender, year: year, month: month, day: day, hour: hour)
-        let startAge = childLimit.years
+        // Use ChildLimit to get start age
+        let birthTime = SolarTime.fromYmdHms(year, month, day, hour, 0, 0)
+        let childLimit = ChildLimit(birthTime: birthTime, gender: gender)
+        let startAge = childLimit.getYearCount()
 
         var fortunes: [DecadeFortuneInfo] = []
         var currentSixtyCycle = monthSixtyCycle
@@ -30,7 +26,6 @@ public final class DefaultDecadeFortuneProvider: DecadeFortuneProvider {
             let fortuneStartAge = startAge + i * 10
             let fortuneEndAge = fortuneStartAge + 9
 
-            // Move to next/previous SixtyCycle
             if i > 0 {
                 currentSixtyCycle = currentSixtyCycle.next(isForward ? 1 : -1)
             }

--- a/Sources/tyme/eightchar/provider/LunarSect1ChildLimitProvider.swift
+++ b/Sources/tyme/eightchar/provider/LunarSect1ChildLimitProvider.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Lunar流派1童限计算（按天数和时辰数计算，3天1年，1天4个月，1时辰10天）
+public final class LunarSect1ChildLimitProvider: ChildLimitProvider {
+    public init() {}
+
+    public func getInfo(birthTime: SolarTime, term: SolarTerm) -> ChildLimitInfo {
+        let termTime = term.getJulianDay().getSolarTime()
+        var end = termTime
+        var start = birthTime
+        if birthTime.isAfter(termTime) {
+            end = birthTime
+            start = termTime
+        }
+        let endTimeZhiIndex = end.getHour() == 23 ? 11 : (end.getHour() + 1) / 2
+        let startTimeZhiIndex = start.getHour() == 23 ? 11 : (start.getHour() + 1) / 2
+        // 时辰差
+        var hourDiff = endTimeZhiIndex - startTimeZhiIndex
+        // 天数差
+        var dayDiff = end.getSolarDay().subtract(start.getSolarDay())
+        if hourDiff < 0 {
+            hourDiff += 12
+            dayDiff -= 1
+        }
+        let monthDiff = hourDiff * 10 / 30
+        var month = dayDiff * 4 + monthDiff
+        let day = hourDiff * 10 - monthDiff * 30
+        let year = month / 12
+        month = month - year * 12
+
+        return next(birthTime, year, month, day, 0, 0, 0)
+    }
+}

--- a/Sources/tyme/eightchar/provider/LunarSect2ChildLimitProvider.swift
+++ b/Sources/tyme/eightchar/provider/LunarSect2ChildLimitProvider.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Lunar流派2童限计算（按分钟数计算）
+public final class LunarSect2ChildLimitProvider: ChildLimitProvider {
+    public init() {}
+
+    public func getInfo(birthTime: SolarTime, term: SolarTerm) -> ChildLimitInfo {
+        // 出生时刻和节令时刻相差的分钟数
+        var minutes = abs(term.getJulianDay().getSolarTime().subtract(birthTime)) / 60
+        let year = minutes / 4320
+        minutes %= 4320
+        let month = minutes / 360
+        minutes %= 360
+        let day = minutes / 12
+        minutes %= 12
+        let hour = minutes * 2
+
+        return next(birthTime, year, month, day, hour, 0, 0)
+    }
+}

--- a/Sources/tyme/solar/SolarDay.swift
+++ b/Sources/tyme/solar/SolarDay.swift
@@ -53,6 +53,26 @@ public final class SolarDay: DayUnit, Tyme {
         return SolarWeek(year: getYear(), month: getMonth(), index: index, start: start)
     }
 
+    public func getTermDay() -> SolarTermDay {
+        var y = getYear()
+        var i = getMonth() * 2
+        if i == 24 {
+            y += 1
+            i = 0
+        }
+        var term = SolarTerm.fromIndex(y, i + 1)
+        var termDay = term.getSolarDay()
+        while isBefore(termDay) {
+            term = term.next(-1)
+            termDay = term.getSolarDay()
+        }
+        return SolarTermDay(term, subtract(termDay))
+    }
+
+    public func getTerm() -> SolarTerm {
+        getTermDay().getSolarTerm()
+    }
+
     public func getSixtyCycleDay() -> SixtyCycleDay {
         SixtyCycleDay(solarDay: self)
     }

--- a/Sources/tyme/solar/SolarTime.swift
+++ b/Sources/tyme/solar/SolarTime.swift
@@ -26,4 +26,51 @@ public final class SolarTime: SecondUnit, Tyme {
         let ymd = target.toYmdHms()
         return SolarTime(year: ymd.year, month: ymd.month, day: ymd.day, hour: ymd.hour, minute: ymd.minute, second: ymd.second)
     }
+
+    public func subtract(_ target: SolarTime) -> Int {
+        let days = getSolarDay().subtract(target.getSolarDay())
+        let cs = getHour() * 3600 + getMinute() * 60 + getSecond()
+        let ts = target.getHour() * 3600 + target.getMinute() * 60 + target.getSecond()
+        var seconds = cs - ts
+        var d = days
+        if seconds < 0 {
+            seconds += 86400
+            d -= 1
+        }
+        seconds += d * 86400
+        return seconds
+    }
+
+    public func isAfter(_ target: SolarTime) -> Bool {
+        let d = getSolarDay()
+        let td = target.getSolarDay()
+        if d.getYear() != td.getYear() || d.getMonth() != td.getMonth() || d.getDay() != td.getDay() {
+            return d.isAfter(td)
+        }
+        if getHour() != target.getHour() { return getHour() > target.getHour() }
+        return getMinute() != target.getMinute() ? getMinute() > target.getMinute() : getSecond() > target.getSecond()
+    }
+
+    public func isBefore(_ target: SolarTime) -> Bool {
+        let d = getSolarDay()
+        let td = target.getSolarDay()
+        if d.getYear() != td.getYear() || d.getMonth() != td.getMonth() || d.getDay() != td.getDay() {
+            return d.isBefore(td)
+        }
+        if getHour() != target.getHour() { return getHour() < target.getHour() }
+        return getMinute() != target.getMinute() ? getMinute() < target.getMinute() : getSecond() < target.getSecond()
+    }
+
+    public func getLunarHour() -> LunarHour {
+        let d = getSolarDay().getLunarDay()
+        return LunarHour.fromYmdHms(d.getYear(), d.getMonth(), d.getDay(), getHour(), getMinute(), getSecond())
+    }
+
+    public func getTerm() -> SolarTerm {
+        var term = getSolarDay().getTerm()
+        if isBefore(term.getJulianDay().getSolarTime()) {
+            term = term.next(-1)
+        }
+        return term
+    }
 }


### PR DESCRIPTION
## Summary
- Implement 3 missing EightChar ChildLimit provider variants: `LunarSect1ChildLimitProvider`, `LunarSect2ChildLimitProvider`, `China95ChildLimitProvider`
- Rewrite `ChildLimitProvider` protocol, `ChildLimitInfo`, `ChildLimit` class, and `DefaultChildLimitProvider` to match tyme4j reference architecture
- Add `SolarTime.subtract/isAfter/isBefore/getLunarHour/getTerm` and `SolarDay.getTermDay/getTerm` helper methods

## Provider Algorithms
| Provider | Algorithm | Precision |
|----------|-----------|-----------|
| Default | 3天=1年, seconds-based | Year/Month/Day/Hour/Minute |
| LunarSect1 | 3天=1年, 1天=4月, 1时辰=10天 | Year/Month/Day |
| LunarSect2 | 4320分=1年, minutes-based | Year/Month/Day/Hour |
| China95 | 4320分=1年, minutes-based | Year/Month/Day |

## Notes
- Test values use structural correctness checks (non-negative, endTime > startTime, provider switching) rather than exact Java values, because `ShouXingUtil.qiAccurate2` is currently a simplified stub. Full astronomical alignment requires porting the complete ShouXingUtil from tyme4j.

## Test plan
- [x] `swift build` passes
- [x] All 84 XCTest + 1 Swift Testing tests pass (0 failures)
- [x] New tests: `testChildLimitDefault`, `testChildLimitChina95`, `testChildLimitLunarSect1`, `testChildLimitLunarSect2`, `testChildLimitProviderSwitch`, `testSolarDayGetTerm`, `testSolarTimeSubtract`, `testSolarTimeTerm`

Closes #9