### PR TITLE
fix: Align Element.NAMES order with tyme4j

### DIFF
--- a/Sources/tyme/culture/Element.swift
+++ b/Sources/tyme/culture/Element.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public final class Element: LoopTyme {
-    public static let NAMES = ["金","木","水","火","土"]
+    public static let NAMES = ["木","火","土","金","水"]
     
     // YinYang mapping (阴阳)
     private static let YIN_YANG = ["阳","阴","阳","阴","阳"]

--- a/Tests/tymeTests/Tyme4SwiftTests.swift
+++ b/Tests/tymeTests/Tyme4SwiftTests.swift
@@ -1789,16 +1789,14 @@ final class Tyme4SwiftTests: XCTestCase {
     }
 
     func testMinorRenElement() throws {
-        // Mapping: [0,4,1,3,0,2] → [金,木,水,火,土] index
-        // 大安→木(0→金), 留连→水(4→水), 速喜→火(1→木)...
-        // Wait, Element.NAMES = ["金","木","水","火","土"]
-        // [0,4,1,3,0,2] → [金,土,木,火,金,水]
-        XCTAssertEqual("金", MinorRen.fromIndex(0).getElement().getName()) // 大安
-        XCTAssertEqual("土", MinorRen.fromIndex(1).getElement().getName()) // 留连
-        XCTAssertEqual("木", MinorRen.fromIndex(2).getElement().getName()) // 速喜
-        XCTAssertEqual("火", MinorRen.fromIndex(3).getElement().getName()) // 赤口
-        XCTAssertEqual("金", MinorRen.fromIndex(4).getElement().getName()) // 小吉
-        XCTAssertEqual("水", MinorRen.fromIndex(5).getElement().getName()) // 空亡
+        // Mapping: [0,4,1,3,0,2] → Element.NAMES["木","火","土","金","水"] index
+        // [0,4,1,3,0,2] → [木,水,火,金,木,土]
+        XCTAssertEqual("木", MinorRen.fromIndex(0).getElement().getName()) // 大安
+        XCTAssertEqual("水", MinorRen.fromIndex(1).getElement().getName()) // 留连
+        XCTAssertEqual("火", MinorRen.fromIndex(2).getElement().getName()) // 速喜
+        XCTAssertEqual("金", MinorRen.fromIndex(3).getElement().getName()) // 赤口
+        XCTAssertEqual("木", MinorRen.fromIndex(4).getElement().getName()) // 小吉
+        XCTAssertEqual("土", MinorRen.fromIndex(5).getElement().getName()) // 空亡
     }
 
     func testMinorRenNext() throws {


### PR DESCRIPTION
## Summary
- Change `Element.NAMES` from `["金","木","水","火","土"]` to `["木","火","土","金","水"]` to match tyme4j reference implementation
- Update `testMinorRenElement` expected values to match new NAMES order
- MinorRen index mapping `[0,4,1,3,0,2]` unchanged (same as Java)

## Impact Analysis
- `Element.fromIndex()` — only used in MinorRen.swift (auto-correct with NAMES fix)
- `Element.fromName()` — not affected (name-based lookup)
- `RabByung.ELEMENTS` — independent array, not affected
- `Sound.getElement()` / `NaYin.getElement()` — use `fromName()`, not affected

## Test plan
- [x] All 95 tests pass (94 XCTest + 1 Swift Testing)
- [x] `testMinorRenElement` expectations updated to match Java behavior

Closes #19