### PR TITLE
test: Add acceptance tests for Issue #14 and #19

### DIFF
--- a/Tests/tymeTests/Tyme4SwiftTests.swift
+++ b/Tests/tymeTests/Tyme4SwiftTests.swift
@@ -1807,12 +1807,76 @@ final class Tyme4SwiftTests: XCTestCase {
         XCTAssertEqual("空亡", daAn.next(-1).getName()) // negative
     }
 
-    // Issue #14: SolarDay.getLunarDay() overflow crash
+    // MARK: - Issue #14 Acceptance Tests
+
     func testGetLunarDayNoOverflow() throws {
-        // ThreePillars.getSolarDays internally calls getLunarDay() on many dates
         let tp = ThreePillars(yearName: "甲戌", monthName: "甲戌", dayName: "甲戌")
         let days = tp.getSolarDays(startYear: 1, endYear: 2200)
         XCTAssertFalse(days.isEmpty, "Should find matching solar days without crashing")
+    }
+
+    func testGetLunarDayNoOverflowCount() throws {
+        let tp = ThreePillars(yearName: "甲戌", monthName: "甲戌", dayName: "甲戌")
+        let days = tp.getSolarDays(startYear: 1, endYear: 2200)
+        XCTAssertEqual(days.count, 19, "Should find exactly 19 matching solar days")
+    }
+
+    func testGetLunarDayBoundaryDates() throws {
+        let d1 = SolarDay.fromYmd(1, 2, 12)
+        XCTAssertTrue(d1.getLunarDay().getDay() >= 1 && d1.getLunarDay().getDay() <= 30)
+
+        let d2 = SolarDay.fromYmd(100, 1, 1)
+        XCTAssertTrue(d2.getLunarDay().getDay() >= 1 && d2.getLunarDay().getDay() <= 30)
+
+        // 2024-02-10 is lunar new year
+        XCTAssertEqual("初一", SolarDay.fromYmd(2024, 2, 10).getLunarDay().getName())
+    }
+
+    func testGetLunarDayLeapMonth() throws {
+        let d = SolarDay.fromYmd(2023, 4, 20)
+        XCTAssertTrue(d.getLunarDay().getDay() >= 1 && d.getLunarDay().getDay() <= 30)
+    }
+
+    // MARK: - Issue #19 Acceptance Tests
+
+    func testElementNamesOrder() throws {
+        XCTAssertEqual("木", Element.fromIndex(0).getName())
+        XCTAssertEqual("火", Element.fromIndex(1).getName())
+        XCTAssertEqual("土", Element.fromIndex(2).getName())
+        XCTAssertEqual("金", Element.fromIndex(3).getName())
+        XCTAssertEqual("水", Element.fromIndex(4).getName())
+    }
+
+    func testElementFromName() throws {
+        XCTAssertEqual("木", Element.fromName("木").getName())
+        XCTAssertEqual("金", Element.fromName("金").getName())
+        XCTAssertEqual("水", Element.fromName("水").getName())
+    }
+
+    func testElementCycle() throws {
+        let wood = Element.fromName("木")
+        XCTAssertEqual("火", wood.next(1).getName())
+        XCTAssertEqual("土", wood.next(2).getName())
+        XCTAssertEqual("金", wood.next(3).getName())
+        XCTAssertEqual("水", wood.next(4).getName())
+        XCTAssertEqual("木", wood.next(5).getName())
+    }
+
+    func testElementYinYang() throws {
+        // 木=阳, 火=阴, 土=阳, 金=阴, 水=阳
+        XCTAssertEqual("阳", Element.fromIndex(0).getYinYang()) // 木
+        XCTAssertEqual("阴", Element.fromIndex(1).getYinYang()) // 火
+        XCTAssertEqual("阳", Element.fromIndex(2).getYinYang()) // 土
+        XCTAssertEqual("阴", Element.fromIndex(3).getYinYang()) // 金
+        XCTAssertEqual("阳", Element.fromIndex(4).getYinYang()) // 水
+    }
+
+    func testNineStarElementUnaffected() throws {
+        XCTAssertEqual("水", NineStar.fromIndex(0).getElement().getName())
+    }
+
+    func testSoundElementUnaffected() throws {
+        XCTAssertFalse(Sound.fromIndex(0).getElement().getName().isEmpty)
     }
 }
 


### PR DESCRIPTION
## Summary

Add 10 comprehensive acceptance tests prepared by QA during bug fix sprint.

### Issue #14 Acceptance Tests (4 tests)

| Test | Coverage |
|------|----------|
| testGetLunarDayNoOverflow | ThreePillars scan (year 1-2200) doesn't crash |
| testGetLunarDayNoOverflowCount | Returns exactly 19 matching solar days |
| testGetLunarDayBoundaryDates | Boundary dates validation (year 1, 100, 2024) |
| testGetLunarDayLeapMonth | Leap month handling (2023 闰二月) |

### Issue #19 Acceptance Tests (6 tests)

| Test | Coverage |
|------|----------|
| testElementNamesOrder | fromIndex() returns 木火土金水 in correct order |
| testElementFromName | fromName() works correctly (unaffected by NAMES order) |
| testElementCycle | next() follows correct five-phase cycle |
| testElementYinYang | Yin-Yang mapping: 木阳/火阴/土阳/金阴/水阳 |
| testNineStarElementUnaffected | No regression in NineStar |
| testSoundElementUnaffected | No regression in Sound |

## Test Coverage

- **Before**: 95 tests (94 XCTest + 1 Swift Testing)
- **After**: 105 tests (104 XCTest + 1 Swift Testing)
- **Added**: 10 acceptance tests

## Validation

All tests pass:
```bash
swift test  # 105 tests, 0 failures
```

These tests provide regression protection for the two critical bug fixes merged in PR #21 and PR #22.