### PR TITLE
fix: Update Swift version and remove inaccurate SwiftLint CI claims

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Verify Swift build
         uses: swift-actions/setup-swift@v1
         with:
-          swift-version: '5.9'
+          swift-version: '6.2'
 
       - name: Build Swift package
         run: swift build -v
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Swift
         uses: swift-actions/setup-swift@v1
         with:
-          swift-version: '5.9'
+          swift-version: '6.2'
 
       - name: Verify Package.swift manifest
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,6 @@ brew install swiftlint
 swiftlint lint --path Sources
 ```
 
-**注意**：项目使用 SwiftLint 默认规则。CI 会自动运行 SwiftLint 检查，未通过的 PR 将无法合并。
-
 ### 运行测试
 
 提交前请确保所有测试通过：


### PR DESCRIPTION
## Summary

This PR addresses two Phase 1 infrastructure improvements:

### Issue #26: Update Swift version in publish.yml
- Updated `swift-version` from `'5.9'` to `'6.2'` in both verification and registration jobs
- Ensures the publish workflow uses the current Swift toolchain

### Issue #28: Remove inaccurate SwiftLint CI claims
- Removed incorrect statement about automatic SwiftLint CI checks in CONTRIBUTING.md
- The project recommends SwiftLint for local development, but CI does not enforce it

## Changes
- `.github/workflows/publish.yml`: Swift version 5.9 → 6.2 (2 occurrences)
- `CONTRIBUTING.md`: Removed "CI 会自动运行 SwiftLint 检查" statement

Closes #26, Closes #28