### PR TITLE
fix: Replace embedded Python with jq in CI coverage report (#38)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,15 +30,9 @@ jobs:
         run: |
           CODECOV_JSON=$(swift test --show-codecov-path)
           if [ -f "$CODECOV_JSON" ]; then
-            echo "📊 Code coverage report: $CODECOV_JSON"
-            # 提取覆盖率百分比
-            COVERAGE=$(cat "$CODECOV_JSON" | python3 -c "
-import json, sys
-data = json.load(sys.stdin)
-pct = data['data'][0]['totals']['lines']['percent']
-print(f'{pct:.1f}%')
-")
-            echo "📈 Line coverage: $COVERAGE"
+            echo "Code coverage report: $CODECOV_JSON"
+            COVERAGE=$(jq -r '.data[0].totals.lines.percent' "$CODECOV_JSON")
+            echo "Line coverage: ${COVERAGE}%"
           else
-            echo "⚠️  Coverage report not found"
+            echo "Coverage report not found"
           fi


### PR DESCRIPTION
## Summary
- Replace embedded Python code with `jq` in CI coverage report step
- Fixes YAML parsing error caused by mixed Python/shell indentation in `|` block scalar

## Changes
- `.github/workflows/ci.yml`: Replace multi-line Python snippet (lines 35-40) with single-line `jq` command
- Remove emoji characters from echo statements for cleaner output

## Root Cause
The `|` block scalar in YAML couldn't parse the embedded Python code correctly due to indentation conflicts between shell and Python, plus f-string `{pct:.1f}` syntax interfering with YAML parsing.

Closes #38