### PR TITLE
fix: Replace embedded Python with jq in CI coverage report (#38)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,15 +30,9 @@ jobs:
         run: |
           CODECOV_JSON=$(swift test --show-codecov-path)
           if [ -f "$CODECOV_JSON" ]; then
-            echo "📊 Code coverage report: $CODECOV_JSON"
-            # 提取覆盖率百分比
-            COVERAGE=$(cat "$CODECOV_JSON" | python3 -c "
-import json, sys
-data = json.load(sys.stdin)
-pct = data['data'][0]['totals']['lines']['percent']
-print(f'{pct:.1f}%')
-")
-            echo "📈 Line coverage: $COVERAGE"
+            echo "Code coverage report: $CODECOV_JSON"
+            COVERAGE=$(jq -r '.data[0].totals.lines.percent' "$CODECOV_JSON")
+            echo "Line coverage: ${COVERAGE}%"
           else
-            echo "⚠️  Coverage report not found"
+            echo "Coverage report not found"
           fi


### PR DESCRIPTION
## Summary

Fixes the YAML syntax error in `.github/workflows/ci.yml` by replacing the embedded Python code with `jq` for parsing the code coverage JSON report.

## Changes

- Replace multi-line Python code block (lines 35-40) with `jq` command
- Simplify coverage extraction using `jq -r '.data[0].totals.lines.percent'`
- Remove emoji decorations from echo statements

## Root Cause

The original implementation embedded Python code within a YAML `|` block scalar, which caused YAML parsing errors due to Python indentation and f-string syntax.

Closes #38