### PR TITLE
test: Add regression tests for Issue #42 God/Taboo lookup

### DIFF
--- a/Tests/tymeTests/Tyme4SwiftTests.swift
+++ b/Tests/tymeTests/Tyme4SwiftTests.swift
@@ -1922,5 +1922,30 @@ final class Tyme4SwiftTests: XCTestCase {
             XCTAssertFalse(taboo.getName().isEmpty, "Taboo name should not be empty")
         }
     }
+
+    /// Regression test for Issue #42: God/Taboo lookup data integrity
+    func testGodTabooDataIntegrity() throws {
+        // Test specific date from Issue #42
+        let day = SixtyCycleDay(year: 2024, month: 12, day: 1)
+        let gods = day.getGods()
+        XCTAssertTrue(gods.count > 0, "Gods list should not be empty for 2024-12-01")
+        let recommends = day.getRecommends()
+        XCTAssertNotNil(recommends, "Recommends should not be nil for 2024-12-01")
+        let avoids = day.getAvoids()
+        XCTAssertNotNil(avoids, "Avoids should not be nil for 2024-12-01")
+    }
+
+    /// Stress test: all dates in 2024 should not crash
+    func testGodTabooFullYear2024() throws {
+        let daysInMonth = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+        for m in 1...12 {
+            for d in 1...daysInMonth[m - 1] {
+                let day = SixtyCycleDay(year: 2024, month: m, day: d)
+                let _ = day.getGods()
+                let _ = day.getRecommends()
+                let _ = day.getAvoids()
+            }
+        }
+    }
 }
 


### PR DESCRIPTION
## Summary

Add regression tests to prevent future God/Taboo lookup data integrity issues.

## Changes

- ✅ `testGodTabooDataIntegrity`: Validates 2024-12-01 specifically (the date from Issue #42)
- ✅ `testGodTabooFullYear2024`: Stress test for all 366 dates in 2024

## Context

Issue #42 reported "Index out of range" when calling God/Taboo lookup methods on 2024-12-01. The root cause was incomplete lookup data in PR #41 due to Read tool's 2000-character line truncation.

Commit 44417cb already fixed the issue by replacing incomplete data with complete lookup tables. These tests ensure the fix remains effective and prevent similar data issues in the future.

## Test Results

```
✔ testGodTabooDataIntegrity passed
✔ testGodTabooFullYear2024 passed (366 dates tested)
✔ All 109 tests passed
```

Closes #42