### PR TITLE
feat: Add missing classes (HideHeavenStemDay, PhenologyDay, RabByungElement)

### DIFF
--- a/Sources/tyme/culture/PhenologyDay.swift
+++ b/Sources/tyme/culture/PhenologyDay.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// 物候日 (Phenology Day)
+/// Represents a specific day within a phenology period
+public final class PhenologyDay: AbstractCultureDay {
+    /// Initialize with phenology and day index
+    /// - Parameters:
+    ///   - phenology: The phenology period
+    ///   - dayIndex: Day index within the period (0-based)
+    public init(phenology: Phenology, dayIndex: Int) {
+        super.init(culture: phenology, dayIndex: dayIndex)
+    }
+
+    /// Get phenology
+    /// - Returns: Phenology instance
+    public func getPhenology() -> Phenology {
+        return culture as! Phenology
+    }
+}

--- a/Sources/tyme/sixtycycle/HideHeavenStemDay.swift
+++ b/Sources/tyme/sixtycycle/HideHeavenStemDay.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// 藏干日 (Hidden Heaven Stem Day)
+/// Represents a specific day within a hidden heaven stem period
+public final class HideHeavenStemDay: AbstractCultureDay {
+    /// Initialize with hidden heaven stem and day index
+    /// - Parameters:
+    ///   - hideHeavenStem: The hidden heaven stem
+    ///   - dayIndex: Day index within the period (0-based)
+    public init(hideHeavenStem: HideHeavenStem, dayIndex: Int) {
+        super.init(culture: hideHeavenStem, dayIndex: dayIndex)
+    }
+
+    /// Get hidden heaven stem
+    /// - Returns: HideHeavenStem instance
+    public func getHideHeavenStem() -> HideHeavenStem {
+        return culture as! HideHeavenStem
+    }
+
+    /// Get name
+    /// - Returns: Heaven stem name + element name (e.g., "癸水")
+    public override func getName() -> String {
+        let heavenStem = getHideHeavenStem().getHeavenStem()
+        return heavenStem.getName() + heavenStem.getWuXing()
+    }
+
+    /// String description
+    /// - Returns: Formatted string (e.g., "癸水第1天")
+    public override var description: String {
+        return "\(getName())第\(dayIndex + 1)天"
+    }
+}

--- a/Sources/tyme/tibetan/RabByungElement.swift
+++ b/Sources/tyme/tibetan/RabByungElement.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// 饶迥五行 (Rab-byung Element)
+/// Tibetan calendar element system using 铁 (iron) instead of 金 (metal)
+public final class RabByungElement: AbstractCulture {
+    /// Element names in Tibetan calendar (金→铁)
+    public static let NAMES = ["木", "火", "土", "铁", "水"]
+
+    /// Internal element (uses standard Element)
+    private let element: Element
+
+    /// Initialize with index
+    /// - Parameter index: Element index (0-4)
+    public init(index: Int) {
+        self.element = Element.fromIndex(index)
+        super.init()
+    }
+
+    /// Initialize with name
+    /// - Parameter name: Element name (支持 "铁" 或 "金")
+    public init(name: String) {
+        // Convert 铁 to 金 for internal Element
+        let elementName = name.replacingOccurrences(of: "铁", with: "金")
+        self.element = Element.fromName(elementName)
+        super.init()
+    }
+
+    /// Create from index
+    /// - Parameter index: Element index
+    /// - Returns: RabByungElement instance
+    public static func fromIndex(_ index: Int) -> RabByungElement {
+        return RabByungElement(index: index)
+    }
+
+    /// Create from name
+    /// - Parameter name: Element name
+    /// - Returns: RabByungElement instance
+    public static func fromName(_ name: String) -> RabByungElement {
+        return RabByungElement(name: name)
+    }
+
+    /// Get element name (金→铁)
+    /// - Returns: Element name with 铁 instead of 金
+    public override func getName() -> String {
+        return element.getName().replacingOccurrences(of: "金", with: "铁")
+    }
+
+    /// Get element index
+    /// - Returns: Element index (0-4)
+    public func getIndex() -> Int {
+        return element.getIndex()
+    }
+
+    /// Get next element in cycle
+    /// - Parameter n: Steps to advance (can be negative)
+    /// - Returns: Next RabByungElement
+    public func next(_ n: Int) -> RabByungElement {
+        let nextElement = element.next(n)
+        return RabByungElement(index: nextElement.getIndex())
+    }
+
+    // MARK: - Five Elements Relationships (五行生克)
+
+    /// Get element that this generates (我生者)
+    /// - Returns: Element I reinforce
+    public func getReinforce() -> RabByungElement {
+        return next(1)
+    }
+
+    /// Get element that this restrains (我克者)
+    /// - Returns: Element I restrain
+    public func getRestrain() -> RabByungElement {
+        return next(2)
+    }
+
+    /// Get element that generates this (生我者)
+    /// - Returns: Element that reinforces me
+    public func getReinforced() -> RabByungElement {
+        return next(-1)
+    }
+
+    /// Get element that restrains this (克我者)
+    /// - Returns: Element that restrains me
+    public func getRestrained() -> RabByungElement {
+        return next(-2)
+    }
+}

--- a/Tests/tymeTests/Tyme4SwiftTests.swift
+++ b/Tests/tymeTests/Tyme4SwiftTests.swift
@@ -1947,5 +1947,52 @@ final class Tyme4SwiftTests: XCTestCase {
             }
         }
     }
+
+    // MARK: - HideHeavenStemDay Tests
+
+    func testHideHeavenStemDay() {
+        let eb = EarthBranch.fromIndex(0) // 子
+        let stems = eb.getHideHeavenStems()
+        let day = HideHeavenStemDay(hideHeavenStem: stems[0], dayIndex: 0)
+        XCTAssertEqual(day.getHideHeavenStem().getName(), "癸")
+        XCTAssertEqual(day.getName(), "癸水")  // 癸的五行是水
+        XCTAssertEqual(day.getDayIndex(), 0)
+        XCTAssertEqual(day.description, "癸水第1天")
+    }
+
+    // MARK: - PhenologyDay Tests
+
+    func testPhenologyDay() {
+        let p = Phenology.fromIndex(0)
+        let day = PhenologyDay(phenology: p, dayIndex: 2)
+        XCTAssertEqual(day.getPhenology().getName(), "蚯蚓结")
+        XCTAssertEqual(day.getDayIndex(), 2)
+        XCTAssertEqual(day.getName(), "蚯蚓结")
+        XCTAssertEqual(day.description, "蚯蚓结第3天")
+    }
+
+    // MARK: - RabByungElement Tests
+
+    func testRabByungElement() {
+        let e = RabByungElement(index: 3) // 金→铁
+        XCTAssertEqual(e.getName(), "铁")
+        XCTAssertEqual(e.getIndex(), 3)
+        XCTAssertEqual(e.getReinforce().getName(), "水")  // 铁生水
+        XCTAssertEqual(e.getRestrain().getName(), "木")   // 铁克木
+        XCTAssertEqual(e.getReinforced().getName(), "土") // 土生铁
+        XCTAssertEqual(e.getRestrained().getName(), "火") // 火克铁
+
+        let e2 = RabByungElement.fromName("铁")
+        XCTAssertEqual(e2.getIndex(), 3)
+        XCTAssertEqual(e2.getName(), "铁")
+
+        // Test cycle
+        let wood = RabByungElement.fromName("木")
+        XCTAssertEqual(wood.next(1).getName(), "火")
+        XCTAssertEqual(wood.next(2).getName(), "土")
+        XCTAssertEqual(wood.next(3).getName(), "铁")
+        XCTAssertEqual(wood.next(4).getName(), "水")
+        XCTAssertEqual(wood.next(5).getName(), "木")
+    }
 }
 


### PR DESCRIPTION
## Summary

Implements three missing classes to align with tyme4j (#31):

1. **HideHeavenStemDay** (`Sources/tyme/sixtycycle/`)
   - Extends `AbstractCultureDay` pattern
   - Represents days within a hidden heaven stem period
   - `getName()` returns heavenStem + element (e.g., "癸水")

2. **PhenologyDay** (`Sources/tyme/culture/`)
   - Extends `AbstractCultureDay` pattern  
   - Represents days within a phenology period
   - Simple wrapper around `Phenology` culture

3. **RabByungElement** (`Sources/tyme/tibetan/`)
   - Uses composition pattern (since `Element` is final)
   - Tibetan calendar element with 铁 (iron) replacing 金 (metal)
   - Includes five elements relationships (reinforce/restrain)

## Test Coverage

Added 3 new test methods:
- `testHideHeavenStemDay()` — validates name format and dayIndex
- `testPhenologyDay()` — validates Phenology wrapper
- `testRabByungElement()` — validates 铁/金 conversion and five elements cycle

**All 112 tests passing** (109 existing + 3 new)

## Verification

```bash
swift build  # Build successful
swift test   # 112/112 tests passed
```

Closes #31