### PR TITLE
feat: Add Equatable/Hashable support to LoopTyme

### DIFF
--- a/Sources/tyme/core/LoopTyme.swift
+++ b/Sources/tyme/core/LoopTyme.swift
@@ -37,3 +37,20 @@ open class LoopTyme: AbstractTyme {
         Self.init(names: names, index: index + n)
     }
 }
+
+// MARK: - Equatable
+
+extension LoopTyme: Equatable {
+    public static func == (lhs: LoopTyme, rhs: LoopTyme) -> Bool {
+        return type(of: lhs) == type(of: rhs) && lhs.index == rhs.index
+    }
+}
+
+// MARK: - Hashable
+
+extension LoopTyme: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(type(of: self)))
+        hasher.combine(index)
+    }
+}

--- a/Tests/tymeTests/Tyme4SwiftTests.swift
+++ b/Tests/tymeTests/Tyme4SwiftTests.swift
@@ -1994,5 +1994,37 @@ final class Tyme4SwiftTests: XCTestCase {
         XCTAssertEqual(wood.next(4).getName(), "水")
         XCTAssertEqual(wood.next(5).getName(), "木")
     }
+
+    // MARK: - Equatable/Hashable Tests
+
+    func testLoopTymeEquatable() {
+        // Same type, same index → equal
+        let e1 = Element.fromIndex(0)
+        let e2 = Element.fromIndex(0)
+        XCTAssertEqual(e1, e2)
+        
+        // Same type, different index → not equal
+        let e3 = Element.fromIndex(1)
+        XCTAssertNotEqual(e1, e3)
+        
+        // Different type, same index → not equal
+        let hs = HeavenStem.fromIndex(0)
+        XCTAssertNotEqual(e1 as LoopTyme, hs as LoopTyme)
+        
+        // Cycle equivalence
+        let e4 = Element.fromIndex(5) // wraps to 0
+        XCTAssertEqual(e1, e4)
+    }
+    
+    func testLoopTymeHashable() {
+        // Can be used in Set
+        let set: Set<Element> = [Element.fromIndex(0), Element.fromIndex(0), Element.fromIndex(1)]
+        XCTAssertEqual(set.count, 2)
+        
+        // Can be used as Dictionary key
+        var dict = [HeavenStem: String]()
+        dict[HeavenStem.fromIndex(0)] = "甲"
+        XCTAssertEqual(dict[HeavenStem.fromIndex(0)], "甲")
+    }
 }
 


### PR DESCRIPTION
## Summary

This PR implements Equatable and Hashable protocols for the `LoopTyme` base class and all its subclasses (Element, HeavenStem, EarthBranch, etc.).

## Implementation

- **Equatable**: Two LoopTyme instances are equal if they have the same type AND same index
  - Same type, same index → equal
  - Same type, different index → not equal  
  - Different types, same index → not equal (e.g., `Element(0) != HeavenStem(0)`)
  - Cycle equivalence works correctly (e.g., `Element(0) == Element(5)`)

- **Hashable**: Hash combines type identity and index to ensure proper Set and Dictionary behavior

## Tests

Added two comprehensive test methods:
- `testLoopTymeEquatable`: Verifies equality semantics and cycle equivalence
- `testLoopTymeHashable`: Validates Set deduplication and Dictionary key usage

All 114 tests pass (previously 112, added 2 new tests).

## Part of

Part of #33 (first part - Equatable/Hashable implementation)