### PR TITLE
test: Migrate JulianDayTests to Swift Testing

### DIFF
--- a/Tests/tymeTests/JulianDayTests.swift
+++ b/Tests/tymeTests/JulianDayTests.swift
@@ -1,12 +1,12 @@
-import XCTest
+import Testing
 @testable import tyme
 
-final class JulianDayTests: XCTestCase {
-    func testJulianDay() throws {
+@Suite struct JulianDayTests {
+    @Test func testJulianDay() throws {
         let jd = try JulianDay.fromYmdHms(year: 2000, month: 1, day: 1)
         let solar = jd.getSolarDay()
-        XCTAssertEqual(solar.getYear(), 2000)
-        XCTAssertEqual(solar.getMonth(), 1)
-        XCTAssertEqual(solar.getDay(), 1)
+        #expect(solar.getYear() == 2000)
+        #expect(solar.getMonth() == 1)
+        #expect(solar.getDay() == 1)
     }
 }


### PR DESCRIPTION
## Summary

- Migrate `JulianDayTests` from XCTest to Swift Testing framework
- Replace `import XCTest` with `import Testing`
- Convert `final class JulianDayTests: XCTestCase` to `@Suite struct JulianDayTests`
- Convert `func testJulianDay()` to `@Test func testJulianDay()`
- Replace `XCTAssertEqual(a, b)` with `#expect(a == b)`

This serves as the template/pattern for migrating all remaining test files.

Part of #34