### PR TITLE
ci: Add macOS to CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,18 @@ on:
 jobs:
   build-and-test:
     name: Build and Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Setup Swift
+        if: runner.os == 'Linux'
         uses: swift-actions/setup-swift@v2
         with:
           swift-version: '6.2'


### PR DESCRIPTION
## Summary

- Add `strategy.matrix.os: [ubuntu-latest, macos-latest]` to run CI on both platforms
- Set `fail-fast: false` so both platforms complete independently
- Use `${{ matrix.os }}` for `runs-on`
- Add `if: runner.os == 'Linux'` condition to `swift-actions/setup-swift` step (macOS uses Xcode's built-in Swift)

Closes part of #34