### PR TITLE
test: Migrate small test files to Swift Testing

### DIFF
--- a/Tests/tymeTests/EquatableHashableTests.swift
+++ b/Tests/tymeTests/EquatableHashableTests.swift
@@ -1,33 +1,33 @@
-import XCTest
+import Testing
 @testable import tyme
 
-final class EquatableHashableTests: XCTestCase {
-    func testLoopTymeEquatable() {
+@Suite struct EquatableHashableTests {
+    @Test func testLoopTymeEquatable() {
         // Same type, same index → equal
         let e1 = Element.fromIndex(0)
         let e2 = Element.fromIndex(0)
-        XCTAssertEqual(e1, e2)
-        
+        #expect(e1 == e2)
+
         // Same type, different index → not equal
         let e3 = Element.fromIndex(1)
-        XCTAssertNotEqual(e1, e3)
-        
+        #expect(e1 != e3)
+
         // Different type, same index → not equal
         let hs = HeavenStem.fromIndex(0)
-        XCTAssertNotEqual(e1 as LoopTyme, hs as LoopTyme)
-        
+        #expect(e1 as LoopTyme != hs as LoopTyme)
+
         // Cycle equivalence
         let e4 = Element.fromIndex(5) // wraps to 0
-        XCTAssertEqual(e1, e4)
+        #expect(e1 == e4)
     }
-    func testLoopTymeHashable() {
+    @Test func testLoopTymeHashable() {
         // Can be used in Set
         let set: Set<Element> = [Element.fromIndex(0), Element.fromIndex(0), Element.fromIndex(1)]
-        XCTAssertEqual(set.count, 2)
-        
+        #expect(set.count == 2)
+
         // Can be used as Dictionary key
         var dict = [HeavenStem: String]()
         dict[HeavenStem.fromIndex(0)] = "甲"
-        XCTAssertEqual(dict[HeavenStem.fromIndex(0)], "甲")
+        #expect(dict[HeavenStem.fromIndex(0)] == "甲")
     }
 }

--- a/Tests/tymeTests/LunarTests.swift
+++ b/Tests/tymeTests/LunarTests.swift
@@ -1,29 +1,24 @@
-import XCTest
+import Testing
 @testable import tyme
 
-final class LunarTests: XCTestCase {
-    func testLunarYear() throws {
+@Suite struct LunarTests {
+    @Test func testLunarYear() throws {
         let lunar = try LunarYear.fromYear(2024)
-        XCTAssertNotNil(lunar)
-        XCTAssertEqual(lunar.getYear(), 2024)
+        #expect(lunar.getYear() == 2024)
     }
-    func testLunarEightCharProvider() throws {
+    @Test func testLunarEightCharProvider() throws {
         let provider = LunarEightCharProvider()
 
         // Test year pillar
-        let yearSixtyCycle = provider.getYearSixtyCycle(year: 2024, month: 2, day: 10)
-        XCTAssertNotNil(yearSixtyCycle)
+        _ = provider.getYearSixtyCycle(year: 2024, month: 2, day: 10)
 
         // Test month pillar
-        let monthSixtyCycle = provider.getMonthSixtyCycle(year: 2024, month: 2, day: 10)
-        XCTAssertNotNil(monthSixtyCycle)
+        _ = provider.getMonthSixtyCycle(year: 2024, month: 2, day: 10)
 
         // Test day pillar
-        let daySixtyCycle = provider.getDaySixtyCycle(year: 2024, month: 2, day: 10)
-        XCTAssertNotNil(daySixtyCycle)
+        _ = provider.getDaySixtyCycle(year: 2024, month: 2, day: 10)
 
         // Test hour pillar
-        let hourSixtyCycle = provider.getHourSixtyCycle(year: 2024, month: 2, day: 10, hour: 12)
-        XCTAssertNotNil(hourSixtyCycle)
+        _ = provider.getHourSixtyCycle(year: 2024, month: 2, day: 10, hour: 12)
     }
 }

--- a/Tests/tymeTests/SixtyCycleTests.swift
+++ b/Tests/tymeTests/SixtyCycleTests.swift
@@ -1,185 +1,182 @@
-import XCTest
+import Testing
 @testable import tyme
 
-final class SixtyCycleTests: XCTestCase {
-    func testHeavenStem() throws {
+@Suite struct SixtyCycleTests {
+    @Test func testHeavenStem() throws {
         let stem = HeavenStem.fromIndex(0)
-        XCTAssertEqual(stem.getName(), "甲")
+        #expect(stem.getName() == "甲")
         let stem2 = stem.next(1)
-        XCTAssertEqual(stem2.getName(), "乙")
+        #expect(stem2.getName() == "乙")
     }
-    func testEarthBranch() throws {
+    @Test func testEarthBranch() throws {
         let branch = EarthBranch.fromIndex(0)
-        XCTAssertEqual(branch.getName(), "子")
+        #expect(branch.getName() == "子")
         let branch2 = branch.next(1)
-        XCTAssertEqual(branch2.getName(), "丑")
+        #expect(branch2.getName() == "丑")
     }
-    func testSixtyCycle() throws {
+    @Test func testSixtyCycle() throws {
         let cycle = SixtyCycle.fromIndex(0)
-        XCTAssertEqual(cycle.getName(), "甲子")
+        #expect(cycle.getName() == "甲子")
         let cycle2 = cycle.next(1)
-        XCTAssertEqual(cycle2.getName(), "乙丑")
+        #expect(cycle2.getName() == "乙丑")
     }
-    func testHideHeavenStemType() throws {
+    @Test func testHideHeavenStemType() throws {
         // Test Main
         let main = HideHeavenStemType.main
-        XCTAssertEqual(main.name, "本气")
-        XCTAssertEqual(main.rawValue, 0)
-        XCTAssertTrue(main.isMain)
-        XCTAssertFalse(main.isMiddle)
-        XCTAssertFalse(main.isResidual)
+        #expect(main.name == "本气")
+        #expect(main.rawValue == 0)
+        #expect(main.isMain)
+        #expect(!main.isMiddle)
+        #expect(!main.isResidual)
 
         // Test Middle
         let middle = HideHeavenStemType.middle
-        XCTAssertEqual(middle.name, "中气")
-        XCTAssertEqual(middle.rawValue, 1)
-        XCTAssertFalse(middle.isMain)
-        XCTAssertTrue(middle.isMiddle)
-        XCTAssertFalse(middle.isResidual)
+        #expect(middle.name == "中气")
+        #expect(middle.rawValue == 1)
+        #expect(!middle.isMain)
+        #expect(middle.isMiddle)
+        #expect(!middle.isResidual)
 
         // Test Residual
         let residual = HideHeavenStemType.residual
-        XCTAssertEqual(residual.name, "余气")
-        XCTAssertEqual(residual.rawValue, 2)
-        XCTAssertFalse(residual.isMain)
-        XCTAssertFalse(residual.isMiddle)
-        XCTAssertTrue(residual.isResidual)
+        #expect(residual.name == "余气")
+        #expect(residual.rawValue == 2)
+        #expect(!residual.isMain)
+        #expect(!residual.isMiddle)
+        #expect(residual.isResidual)
 
         // Test fromIndex
-        XCTAssertEqual(HideHeavenStemType.fromIndex(0), .main)
-        XCTAssertEqual(HideHeavenStemType.fromIndex(1), .middle)
-        XCTAssertEqual(HideHeavenStemType.fromIndex(2), .residual)
-        XCTAssertEqual(HideHeavenStemType.fromIndex(3), .main)
+        #expect(HideHeavenStemType.fromIndex(0) == .main)
+        #expect(HideHeavenStemType.fromIndex(1) == .middle)
+        #expect(HideHeavenStemType.fromIndex(2) == .residual)
+        #expect(HideHeavenStemType.fromIndex(3) == .main)
 
         // Test fromName
-        XCTAssertEqual(HideHeavenStemType.fromName("本气"), .main)
-        XCTAssertEqual(HideHeavenStemType.fromName("中气"), .middle)
-        XCTAssertEqual(HideHeavenStemType.fromName("余气"), .residual)
+        #expect(HideHeavenStemType.fromName("本气") == .main)
+        #expect(HideHeavenStemType.fromName("中气") == .middle)
+        #expect(HideHeavenStemType.fromName("余气") == .residual)
 
         // Test description
-        XCTAssertEqual(String(describing: main), "本气")
+        #expect(String(describing: main) == "本气")
     }
-    func testHideHeavenStem() throws {
+    @Test func testHideHeavenStem() throws {
         // Test 子 branch hidden stems (癸)
         let zi = EarthBranch.fromIndex(0)
         let ziHideStems = zi.getHideHeavenStems()
-        XCTAssertEqual(ziHideStems.count, 1)
-        XCTAssertEqual(ziHideStems[0].getName(), "癸")
-        XCTAssertTrue(ziHideStems[0].isMain())
+        #expect(ziHideStems.count == 1)
+        #expect(ziHideStems[0].getName() == "癸")
+        #expect(ziHideStems[0].isMain())
 
         // Test 丑 branch hidden stems (己癸辛)
         let chou = EarthBranch.fromIndex(1)
         let chouHideStems = chou.getHideHeavenStems()
-        XCTAssertEqual(chouHideStems.count, 3)
-        XCTAssertEqual(chouHideStems[0].getName(), "己")
-        XCTAssertEqual(chouHideStems[1].getName(), "癸")
-        XCTAssertEqual(chouHideStems[2].getName(), "辛")
+        #expect(chouHideStems.count == 3)
+        #expect(chouHideStems[0].getName() == "己")
+        #expect(chouHideStems[1].getName() == "癸")
+        #expect(chouHideStems[2].getName() == "辛")
 
         // Test 寅 branch hidden stems (甲丙戊)
         let yin = EarthBranch.fromIndex(2)
         let yinHideStems = yin.getHideHeavenStems()
-        XCTAssertEqual(yinHideStems.count, 3)
-        XCTAssertEqual(yinHideStems[0].getName(), "甲")
-        XCTAssertTrue(yinHideStems[0].isMain())
-        XCTAssertEqual(yinHideStems[1].getName(), "丙")
-        XCTAssertTrue(yinHideStems[1].isMiddle())
-        XCTAssertEqual(yinHideStems[2].getName(), "戊")
-        XCTAssertTrue(yinHideStems[2].isResidual())
+        #expect(yinHideStems.count == 3)
+        #expect(yinHideStems[0].getName() == "甲")
+        #expect(yinHideStems[0].isMain())
+        #expect(yinHideStems[1].getName() == "丙")
+        #expect(yinHideStems[1].isMiddle())
+        #expect(yinHideStems[2].getName() == "戊")
+        #expect(yinHideStems[2].isResidual())
 
         // Test getMainHideHeavenStem
         let mainStem = zi.getMainHideHeavenStem()
-        XCTAssertNotNil(mainStem)
-        XCTAssertEqual(mainStem?.getName(), "癸")
+        #expect(mainStem != nil)
+        #expect(mainStem?.getName() == "癸")
     }
-    func testSixtyCycleYear() throws {
+    @Test func testSixtyCycleYear() throws {
         // Test year 2024 (甲辰年)
         let year2024 = SixtyCycleYear.fromYear(2024)
-        XCTAssertEqual(year2024.getYear(), 2024)
-        XCTAssertEqual(year2024.getName(), "甲辰")
-        XCTAssertEqual(year2024.getHeavenStem().getName(), "甲")
-        XCTAssertEqual(year2024.getEarthBranch().getName(), "辰")
-        XCTAssertEqual(year2024.getZodiac().getName(), "龙")
+        #expect(year2024.getYear() == 2024)
+        #expect(year2024.getName() == "甲辰")
+        #expect(year2024.getHeavenStem().getName() == "甲")
+        #expect(year2024.getEarthBranch().getName() == "辰")
+        #expect(year2024.getZodiac().getName() == "龙")
 
         // Test year 2023 (癸卯年)
         let year2023 = SixtyCycleYear.fromYear(2023)
-        XCTAssertEqual(year2023.getName(), "癸卯")
-        XCTAssertEqual(year2023.getZodiac().getName(), "兔")
+        #expect(year2023.getName() == "癸卯")
+        #expect(year2023.getZodiac().getName() == "兔")
 
         // Test next
         let year2025 = year2024.next(1)
-        XCTAssertEqual(year2025.getYear(), 2025)
-        XCTAssertEqual(year2025.getName(), "乙巳")
+        #expect(year2025.getYear() == 2025)
+        #expect(year2025.getName() == "乙巳")
 
         // Test NaYin
-        let naYin = year2024.getNaYin()
-        XCTAssertNotNil(naYin)
+        _ = year2024.getNaYin()
     }
-    func testSixtyCycleMonth() throws {
+    @Test func testSixtyCycleMonth() throws {
         // Test 2024年1月
         let month = SixtyCycleMonth.fromYm(2024, 1)
-        XCTAssertEqual(month.getYear(), 2024)
-        XCTAssertEqual(month.getMonth(), 1)
-        XCTAssertNotNil(month.getHeavenStem())
-        XCTAssertNotNil(month.getEarthBranch())
-        XCTAssertNotNil(month.getSixtyCycle())
-        XCTAssertNotNil(month.getNaYin())
+        #expect(month.getYear() == 2024)
+        #expect(month.getMonth() == 1)
+        _ = month.getHeavenStem()
+        _ = month.getEarthBranch()
+        _ = month.getSixtyCycle()
+        _ = month.getNaYin()
 
         // Test next
         let nextMonth = month.next(1)
-        XCTAssertEqual(nextMonth.getMonth(), 2)
+        #expect(nextMonth.getMonth() == 2)
 
         // Test wrap around
         let decMonth = SixtyCycleMonth.fromYm(2024, 12)
         let janMonth = decMonth.next(1)
-        XCTAssertEqual(janMonth.getYear(), 2025)
-        XCTAssertEqual(janMonth.getMonth(), 1)
+        #expect(janMonth.getYear() == 2025)
+        #expect(janMonth.getMonth() == 1)
     }
-    func testSixtyCycleDay() throws {
+    @Test func testSixtyCycleDay() throws {
         // Test a specific date
         let day = try SixtyCycleDay.fromYmd(2024, 2, 10)
-        XCTAssertNotNil(day.getSixtyCycle())
-        XCTAssertNotNil(day.getHeavenStem())
-        XCTAssertNotNil(day.getEarthBranch())
-        XCTAssertNotNil(day.getNaYin())
-        XCTAssertNotNil(day.getDuty())
-        XCTAssertNotNil(day.getTwentyEightStar())
+        _ = day.getSixtyCycle()
+        _ = day.getHeavenStem()
+        _ = day.getEarthBranch()
+        _ = day.getNaYin()
+        _ = day.getDuty()
+        _ = day.getTwentyEightStar()
 
         // Test next
-        let nextDay = day.next(1)
-        XCTAssertNotNil(nextDay)
+        _ = day.next(1)
 
         // Test fromSolarDay
         let solarDay = try SolarDay.fromYmd(2024, 2, 10)
         let day2 = SixtyCycleDay.fromSolarDay(solarDay)
-        XCTAssertEqual(day.getName(), day2.getName())
+        #expect(day.getName() == day2.getName())
     }
-    func testSixtyCycleHour() throws {
+    @Test func testSixtyCycleHour() throws {
         // Test a specific time
         let hour = try SixtyCycleHour.fromYmdHms(2024, 2, 10, 12, 0, 0)
-        XCTAssertNotNil(hour.getSixtyCycle())
-        XCTAssertNotNil(hour.getHeavenStem())
-        XCTAssertNotNil(hour.getEarthBranch())
-        XCTAssertNotNil(hour.getNaYin())
+        _ = hour.getSixtyCycle()
+        _ = hour.getHeavenStem()
+        _ = hour.getEarthBranch()
+        _ = hour.getNaYin()
 
         // Test getIndexInDay
         let hourIndex = hour.getIndexInDay()
-        XCTAssertEqual(hourIndex, 6) // 12:00 is 午时 (index 6)
+        #expect(hourIndex == 6) // 12:00 is 午时 (index 6)
 
         // Test 子时 (23:00-01:00)
         let ziHour = try SixtyCycleHour.fromYmdHms(2024, 2, 10, 0, 0, 0)
-        XCTAssertEqual(ziHour.getIndexInDay(), 0)
+        #expect(ziHour.getIndexInDay() == 0)
 
         // Test next
-        let nextHour = hour.next(1)
-        XCTAssertNotNil(nextHour)
+        _ = hour.next(1)
     }
-    func testHideHeavenStemDay() {
+    @Test func testHideHeavenStemDay() {
         let eb = EarthBranch.fromIndex(0) // 子
         let stems = eb.getHideHeavenStems()
         let day = HideHeavenStemDay(hideHeavenStem: stems[0], dayIndex: 0)
-        XCTAssertEqual(day.getHideHeavenStem().getName(), "癸")
-        XCTAssertEqual(day.getName(), "癸水")  // 癸的五行是水
-        XCTAssertEqual(day.getDayIndex(), 0)
-        XCTAssertEqual(day.description, "癸水第1天")
+        #expect(day.getHideHeavenStem().getName() == "癸")
+        #expect(day.getName() == "癸水")  // 癸的五行是水
+        #expect(day.getDayIndex() == 0)
+        #expect(day.description == "癸水第1天")
     }
 }

--- a/Tests/tymeTests/SolarTests.swift
+++ b/Tests/tymeTests/SolarTests.swift
@@ -1,38 +1,36 @@
-import XCTest
+import Testing
 @testable import tyme
 
-final class SolarTests: XCTestCase {
-    func testSolarDay() throws {
+@Suite struct SolarTests {
+    @Test func testSolarDay() throws {
         let solar = try SolarDay(year: 2024, month: 2, day: 10)
-        XCTAssertEqual(solar.getYear(), 2024)
-        XCTAssertEqual(solar.getMonth(), 2)
-        XCTAssertEqual(solar.getDay(), 10)
+        #expect(solar.getYear() == 2024)
+        #expect(solar.getMonth() == 2)
+        #expect(solar.getDay() == 10)
     }
-    func testSolarTerm() throws {
+    @Test func testSolarTerm() throws {
         let term = try SolarTerm(year: 2024, index: 0)
-        XCTAssertEqual(term.getName(), "冬至")
-        XCTAssertEqual(term.getYear(), 2024)
+        #expect(term.getName() == "冬至")
+        #expect(term.getYear() == 2024)
     }
-    func testSolarDayGetTerm() throws {
+    @Test func testSolarDayGetTerm() throws {
         // Verify getTerm returns a valid solar term
         let sd = try SolarDay.fromYmd(2022, 3, 9)
         let term = sd.getTerm()
-        XCTAssertNotNil(term)
         // March 9 is after 惊蛰 (~March 5) and before 春分 (~March 20)
         // With current ShouXingUtil, we verify it returns a valid term
-        XCTAssertTrue(term.index >= 0 && term.index < 24)
+        #expect(term.index >= 0 && term.index < 24)
     }
-    func testSolarTimeSubtract() throws {
+    @Test func testSolarTimeSubtract() throws {
         let t1 = try SolarTime.fromYmdHms(2024, 1, 1, 12, 0, 0)
         let t2 = try SolarTime.fromYmdHms(2024, 1, 1, 10, 0, 0)
-        XCTAssertEqual(t1.subtract(t2), 7200) // 2 hours = 7200 seconds
+        #expect(t1.subtract(t2) == 7200) // 2 hours = 7200 seconds
 
         let t3 = try SolarTime.fromYmdHms(2024, 1, 2, 0, 0, 0)
-        XCTAssertEqual(t3.subtract(t1), 43200) // 12 hours
+        #expect(t3.subtract(t1) == 43200) // 12 hours
     }
-    func testSolarTimeTerm() throws {
+    @Test func testSolarTimeTerm() throws {
         let t1 = try SolarTime.fromYmdHms(2024, 3, 20, 12, 0, 0)
-        let term = t1.getTerm()
-        XCTAssertNotNil(term)
+        _ = t1.getTerm()
     }
 }


### PR DESCRIPTION
## Summary

Migrate 4 small test files from XCTest to Swift Testing framework:

- `EquatableHashableTests.swift` (2 tests)
- `SolarTests.swift` (5 tests)
- `LunarTests.swift` (2 tests)
- `SixtyCycleTests.swift` (10 tests)

### Migration changes
- `import XCTest` → `import Testing`
- `final class XxxTests: XCTestCase` → `@Suite struct XxxTests`
- `func testXxx()` → `@Test func testXxx()`
- `XCTAssertEqual(a, b)` → `#expect(a == b)`
- `XCTAssertNotEqual(a, b)` → `#expect(a != b)`
- `XCTAssertTrue(expr)` → `#expect(expr)`
- `XCTAssertFalse(expr)` → `#expect(!expr)`
- `XCTAssertNotNil(x)` on optional type → `#expect(x != nil)`
- `XCTAssertNotNil(x)` on non-optional type → removed (always true)

All 114 tests pass locally (`swift test`).

Part of #34