### PR TITLE
refactor: Add computed properties for core/jd/unit/pengzu modules

### DIFF
--- a/Sources/tyme/core/AbstractCultureDay.swift
+++ b/Sources/tyme/core/AbstractCultureDay.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 open class AbstractCultureDay: AbstractCulture {
-    internal let culture: Culture
-    internal let dayIndex: Int
+    public let culture: Culture
+    public let dayIndex: Int
 
     public init(culture: Culture, dayIndex: Int) {
         self.culture = culture
@@ -10,6 +10,7 @@ open class AbstractCultureDay: AbstractCulture {
         super.init()
     }
 
+    @available(*, deprecated, renamed: "dayIndex")
     public func getDayIndex() -> Int { dayIndex }
 
     public override func getName() -> String {

--- a/Sources/tyme/core/LoopTyme.swift
+++ b/Sources/tyme/core/LoopTyme.swift
@@ -2,7 +2,7 @@ import Foundation
 
 open class LoopTyme: AbstractTyme {
     internal let names: [String]
-    internal let index: Int
+    public let index: Int
 
     public required init(names: [String], index: Int) {
         self.names = names
@@ -20,6 +20,7 @@ open class LoopTyme: AbstractTyme {
         self.init(names: names, index: i)
     }
 
+    @available(*, deprecated, renamed: "index")
     public func getIndex() -> Int { index }
 
     public func nextIndex(_ n: Int) -> Int {

--- a/Sources/tyme/jd/JulianDay.swift
+++ b/Sources/tyme/jd/JulianDay.swift
@@ -33,6 +33,7 @@ public struct JulianDay: CustomStringConvertible {
         return JulianDay(jd)
     }
 
+    @available(*, deprecated, renamed: "value")
     public func getDay() -> Double { value }
 
     public func toYmdHms() -> (year: Int, month: Int, day: Int, hour: Int, minute: Int, second: Int) {
@@ -65,16 +66,25 @@ public struct JulianDay: CustomStringConvertible {
 
     public func next(_ n: Int) -> JulianDay { JulianDay(value + Double(n)) }
 
-    public func getSolarTime() -> SolarTime {
+    public var solarTime: SolarTime {
         let ymd = toYmdHms()
         return try! SolarTime.fromYmdHms(ymd.year, ymd.month, ymd.day, ymd.hour, ymd.minute, ymd.second)
     }
 
-    public func getSolarDay() -> SolarDay { try! getSolarTime().getSolarDay() }
+    public var solarDay: SolarDay { solarTime.getSolarDay() }
 
-    public func getWeek() -> Week {
+    public var week: Week {
         Week.fromIndex(Int(value + 0.5) + 7000001)
     }
+
+    @available(*, deprecated, renamed: "solarTime")
+    public func getSolarTime() -> SolarTime { solarTime }
+
+    @available(*, deprecated, renamed: "solarDay")
+    public func getSolarDay() -> SolarDay { solarDay }
+
+    @available(*, deprecated, renamed: "week")
+    public func getWeek() -> Week { week }
 
     public func subtract(_ target: JulianDay) -> Double { value - target.value }
 }

--- a/Sources/tyme/lunar/LunarWeek.swift
+++ b/Sources/tyme/lunar/LunarWeek.swift
@@ -15,46 +15,46 @@ public final class LunarWeek: WeekUnit, Tyme {
         try LunarWeek.validate(year: year, month: month, index: index, start: start)
         try super.init(year: year, month: month)
         self.index = index
-        self.start = start
+        self.startIndex = start
     }
 
     public static func fromYm(_ year: Int, _ month: Int, _ index: Int, _ start: Int) throws -> LunarWeek {
         try LunarWeek(year: year, month: month, index: index, start: start)
     }
 
-    public func getLunarMonth() -> LunarMonth { try! LunarMonth.fromYm(getYear(), try! getMonth()) }
+    public func getLunarMonth() -> LunarMonth { try! LunarMonth.fromYm(year, month) }
 
-    public func getName() -> String { LunarWeek.NAMES[getIndex()] }
+    public func getName() -> String { LunarWeek.NAMES[index] }
 
     public func next(_ n: Int) -> LunarWeek {
-        if n == 0 { return try! LunarWeek(year: getYear(), month: getMonth(), index: index, start: start) }
+        if n == 0 { return try! LunarWeek(year: year, month: month, index: index, start: startIndex) }
         var d = index + n
         var m = getLunarMonth()
         if n > 0 {
-            var weekCount = m.getWeekCount(start)
+            var weekCount = m.getWeekCount(startIndex)
             while d >= weekCount {
                 d -= weekCount
                 m = m.next(1)
-                if m.getFirstDay().getWeek().getIndex() != start { d += 1 }
-                weekCount = m.getWeekCount(start)
+                if m.getFirstDay().getWeek().index != startIndex { d += 1 }
+                weekCount = m.getWeekCount(startIndex)
             }
         } else {
             while d < 0 {
-                if m.getFirstDay().getWeek().getIndex() != start { d -= 1 }
+                if m.getFirstDay().getWeek().index != startIndex { d -= 1 }
                 m = m.next(-1)
-                d += m.getWeekCount(start)
+                d += m.getWeekCount(startIndex)
             }
         }
-        return try! LunarWeek(year: m.getYear(), month: m.getMonthWithLeap(), index: d, start: start)
+        return try! LunarWeek(year: m.year, month: m.getMonthWithLeap(), index: d, start: startIndex)
     }
 
     public func getFirstDay() -> LunarDay {
-        let firstDay = try! LunarDay.fromYmd(getYear(), try! getMonth(), 1)
-        return firstDay.next(index * 7 - indexOf(firstDay.getWeek().getIndex() - start, 7))
+        let firstDay = try! LunarDay.fromYmd(year, month, 1)
+        return firstDay.next(index * 7 - indexOf(firstDay.getWeek().index - startIndex, 7))
     }
 
     public func getDays() -> [LunarDay] {
-        let d = try! getFirstDay()
+        let d = getFirstDay()
         return (0..<7).map { d.next($0) }
     }
 }

--- a/Sources/tyme/pengzu/PengZu.swift
+++ b/Sources/tyme/pengzu/PengZu.swift
@@ -16,10 +16,10 @@ import Foundation
 /// - 乙丑日: "乙不栽植千株不长 丑不冠带主不还乡"
 public final class PengZu: AbstractCulture {
     /// 天干彭祖百忌 (Heaven Stem taboo)
-    private let pengZuHeavenStem: PengZuHeavenStem
+    public let pengZuHeavenStem: PengZuHeavenStem
 
     /// 地支彭祖百忌 (Earth Branch taboo)
-    private let pengZuEarthBranch: PengZuEarthBranch
+    public let pengZuEarthBranch: PengZuEarthBranch
 
     /// Initialize from SixtyCycle
     /// - Parameter sixtyCycle: The sixty-cycle (干支) for the day
@@ -52,33 +52,27 @@ public final class PengZu: AbstractCulture {
         return "\(pengZuHeavenStem) \(pengZuEarthBranch)"
     }
 
-    /// Get the Heaven Stem taboo
-    /// - Returns: PengZuHeavenStem instance
-    public func getPengZuHeavenStem() -> PengZuHeavenStem {
-        return pengZuHeavenStem
-    }
+    /// The Heaven Stem taboo text
+    public var heavenStemTaboo: String { pengZuHeavenStem.getName() }
 
-    /// Get the Earth Branch taboo
-    /// - Returns: PengZuEarthBranch instance
-    public func getPengZuEarthBranch() -> PengZuEarthBranch {
-        return pengZuEarthBranch
-    }
+    /// The Earth Branch taboo text
+    public var earthBranchTaboo: String { pengZuEarthBranch.getName() }
 
-    /// Get the Heaven Stem taboo text
-    /// - Returns: Heaven Stem taboo description
-    public func getHeavenStemTaboo() -> String {
-        return pengZuHeavenStem.getName()
-    }
+    /// All taboos as an array
+    public var taboos: [String] { [pengZuHeavenStem.getName(), pengZuEarthBranch.getName()] }
 
-    /// Get the Earth Branch taboo text
-    /// - Returns: Earth Branch taboo description
-    public func getEarthBranchTaboo() -> String {
-        return pengZuEarthBranch.getName()
-    }
+    @available(*, deprecated, renamed: "pengZuHeavenStem")
+    public func getPengZuHeavenStem() -> PengZuHeavenStem { pengZuHeavenStem }
 
-    /// Get all taboos as an array
-    /// - Returns: Array containing both Heaven Stem and Earth Branch taboos
-    public func getTaboos() -> [String] {
-        return [pengZuHeavenStem.getName(), pengZuEarthBranch.getName()]
-    }
+    @available(*, deprecated, renamed: "pengZuEarthBranch")
+    public func getPengZuEarthBranch() -> PengZuEarthBranch { pengZuEarthBranch }
+
+    @available(*, deprecated, renamed: "heavenStemTaboo")
+    public func getHeavenStemTaboo() -> String { heavenStemTaboo }
+
+    @available(*, deprecated, renamed: "earthBranchTaboo")
+    public func getEarthBranchTaboo() -> String { earthBranchTaboo }
+
+    @available(*, deprecated, renamed: "taboos")
+    public func getTaboos() -> [String] { taboos }
 }

--- a/Sources/tyme/solar/SolarWeek.swift
+++ b/Sources/tyme/solar/SolarWeek.swift
@@ -15,19 +15,19 @@ public final class SolarWeek: WeekUnit, Tyme {
         try SolarWeek.validate(year: year, month: month, index: index, start: start)
         try super.init(year: year, month: month)
         self.index = index
-        self.start = start
+        self.startIndex = start
     }
 
     public static func fromYm(_ year: Int, _ month: Int, _ index: Int, _ start: Int) throws -> SolarWeek {
         try SolarWeek(year: year, month: month, index: index, start: start)
     }
 
-    public func getSolarMonth() -> SolarMonth { try! SolarMonth(year: getYear(), month: getMonth()) }
+    public func getSolarMonth() -> SolarMonth { try! SolarMonth(year: year, month: month) }
 
     public func getIndexInYear() -> Int {
         var i = 0
-        let firstDay = try! getFirstDay()
-        var w = try! SolarWeek(year: getYear(), month: 1, index: 0, start: start)
+        let firstDay = getFirstDay()
+        var w = try! SolarWeek(year: year, month: 1, index: 0, start: startIndex)
         while w.getFirstDay().getName() != firstDay.getName() {
             w = w.next(1)
             i += 1
@@ -35,38 +35,38 @@ public final class SolarWeek: WeekUnit, Tyme {
         return i
     }
 
-    public func getName() -> String { SolarWeek.NAMES[getIndex()] }
+    public func getName() -> String { SolarWeek.NAMES[index] }
 
     public func next(_ n: Int) -> SolarWeek {
         var d = index
         var m = getSolarMonth()
         if n > 0 {
             d += n
-            var weekCount = m.getWeekCount(start)
+            var weekCount = m.getWeekCount(startIndex)
             while d >= weekCount {
                 d -= weekCount
                 m = m.next(1)
-                if m.getFirstDay().getWeek().getIndex() != start { d += 1 }
-                weekCount = m.getWeekCount(start)
+                if m.getFirstDay().getWeek().index != startIndex { d += 1 }
+                weekCount = m.getWeekCount(startIndex)
             }
         } else if n < 0 {
             d += n
             while d < 0 {
-                if m.getFirstDay().getWeek().getIndex() != start { d -= 1 }
+                if m.getFirstDay().getWeek().index != startIndex { d -= 1 }
                 m = m.next(-1)
-                d += m.getWeekCount(start)
+                d += m.getWeekCount(startIndex)
             }
         }
-        return try! SolarWeek(year: m.getYear(), month: m.getMonth(), index: d, start: start)
+        return try! SolarWeek(year: m.year, month: m.month, index: d, start: startIndex)
     }
 
     public func getFirstDay() -> SolarDay {
-        let firstDay = try! SolarDay(year: getYear(), month: getMonth(), day: 1)
-        return firstDay.next(index * 7 - indexOf(firstDay.getWeek().getIndex() - start, 7))
+        let firstDay = try! SolarDay(year: year, month: month, day: 1)
+        return firstDay.next(index * 7 - indexOf(firstDay.getWeek().index - startIndex, 7))
     }
 
     public func getDays() -> [SolarDay] {
-        let d = try! getFirstDay()
+        let d = getFirstDay()
         return (0..<7).map { d.next($0) }
     }
 }

--- a/Sources/tyme/unit/DayUnit.swift
+++ b/Sources/tyme/unit/DayUnit.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 open class DayUnit: MonthUnit {
-    internal let day: Int
+    public let day: Int
 
     public init(year: Int, month: Int, day: Int) throws {
         if day < 1 || day > 31 {
@@ -11,5 +11,6 @@ open class DayUnit: MonthUnit {
         try super.init(year: year, month: month)
     }
 
+    @available(*, deprecated, renamed: "day")
     public func getDay() -> Int { day }
 }

--- a/Sources/tyme/unit/MonthUnit.swift
+++ b/Sources/tyme/unit/MonthUnit.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 open class MonthUnit: YearUnit {
-    private let month: Int
+    public let month: Int
 
     public init(year: Int, month: Int) throws {
         if month < 1 || month > 12 {
@@ -11,5 +11,6 @@ open class MonthUnit: YearUnit {
         try super.init(year: year)
     }
 
+    @available(*, deprecated, renamed: "month")
     public func getMonth() -> Int { month }
 }

--- a/Sources/tyme/unit/SecondUnit.swift
+++ b/Sources/tyme/unit/SecondUnit.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 open class SecondUnit: DayUnit {
-    internal let hour: Int
-    internal let minute: Int
-    internal let second: Int
+    public let hour: Int
+    public let minute: Int
+    public let second: Int
 
     public static func validate(hour: Int, minute: Int, second: Int) throws {
         if hour < 0 || hour > 23 { throw TymeError.invalidHour(hour) }
@@ -19,7 +19,10 @@ open class SecondUnit: DayUnit {
         try super.init(year: year, month: month, day: day)
     }
 
+    @available(*, deprecated, renamed: "hour")
     public func getHour() -> Int { hour }
+    @available(*, deprecated, renamed: "minute")
     public func getMinute() -> Int { minute }
+    @available(*, deprecated, renamed: "second")
     public func getSecond() -> Int { second }
 }

--- a/Sources/tyme/unit/WeekUnit.swift
+++ b/Sources/tyme/unit/WeekUnit.swift
@@ -1,12 +1,16 @@
 import Foundation
 
 open class WeekUnit: MonthUnit {
-    internal var index: Int = 0
-    internal var start: Int = 0
+    public var index: Int = 0
+    public var startIndex: Int = 0
 
+    public var start: Week { Week.fromIndex(startIndex) }
+
+    @available(*, deprecated, renamed: "index")
     public func getIndex() -> Int { index }
 
-    public func getStart() -> Week { Week.fromIndex(start) }
+    @available(*, deprecated, renamed: "start")
+    public func getStart() -> Week { start }
 
     public static func validate(index: Int, start: Int) throws {
         if index < 0 || index > 5 { throw TymeError.invalidIndex(index) }

--- a/Sources/tyme/unit/YearUnit.swift
+++ b/Sources/tyme/unit/YearUnit.swift
@@ -1,13 +1,14 @@
 import Foundation
 
 open class YearUnit {
-    internal let year: Int
+    public let year: Int
 
     public init(year: Int) throws {
         try SolarUtil.validateYear(year)
         self.year = year
     }
 
+    @available(*, deprecated, renamed: "year")
     public func getYear() -> Int { year }
 
     internal func indexOf(_ index: Int, _ size: Int) -> Int {


### PR DESCRIPTION
## Summary

Phase 3b-1 of the Swift API modernization (Part of #34): expose stored properties as `public` and add computed property wrappers to replace no-arg `getXxx()` methods in **core**, **jd**, **unit**, and **pengzu** modules.

### Source Changes

| File | Changes |
|------|---------|
| `core/LoopTyme.swift` | `index` now `public`; `getIndex()` deprecated |
| `core/AbstractCultureDay.swift` | `culture`, `dayIndex` now `public`; `getDayIndex()` deprecated |
| `jd/JulianDay.swift` | computed `solarTime`, `solarDay`, `week` added; old getters deprecated; `getDay()` → `value` |
| `unit/YearUnit.swift` | `year` now `public`; `getYear()` deprecated |
| `unit/MonthUnit.swift` | `month` now `public`; `getMonth()` deprecated |
| `unit/DayUnit.swift` | `day` now `public`; `getDay()` deprecated |
| `unit/WeekUnit.swift` | `index` public; `start: Int` renamed to `startIndex`; computed `start: Week` added; getters deprecated |
| `unit/SecondUnit.swift` | `hour`, `minute`, `second` now `public`; getters deprecated |
| `pengzu/PengZu.swift` | stored props public; computed `heavenStemTaboo`, `earthBranchTaboo`, `taboos` added; all getters deprecated |
| `solar/SolarWeek.swift` / `lunar/LunarWeek.swift` | updated to use `startIndex` backing store |

### Test Updates

- `JulianDayTests.swift`: use `jd.solarDay`, `solar.year/month/day`
- `CultureTests.swift`: use `pengZu.pengZuHeavenStem/pengZuEarthBranch`, `.heavenStemTaboo/.earthBranchTaboo`, `.taboos`, `.dayIndex`
- `SixtyCycleTests.swift`: use `.dayIndex`

### Backward Compatibility

All existing `getXxx()` methods retained with `@available(*, deprecated, renamed:)` annotations — no breaking changes.

## Test plan

- [x] `swift build` — zero errors (deprecation warnings expected)
- [x] `swift test` — all 114 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)