### PR TITLE
refactor: Add computed properties for tibetan/star modules

### DIFF
--- a/Sources/tyme/star/Dipper.swift
+++ b/Sources/tyme/star/Dipper.swift
@@ -81,45 +81,30 @@ public final class Dipper: LoopTyme {
 
     // MARK: - Properties
 
-    /// Get alternative name
-    /// - Returns: Alternative name (e.g., "贪狼")
-    public func getAlternativeName() -> String {
-        return Dipper.ALTERNATIVE_NAMES[index]
-    }
-
-    /// Get western name
-    /// - Returns: Western name (e.g., "Dubhe")
-    public func getWesternName() -> String {
-        return Dipper.WESTERN_NAMES[index]
-    }
-
-    /// Get position (斗魁 or 斗柄)
-    /// - Returns: Position description
-    public func getPosition() -> String {
-        return Dipper.POSITIONS[index]
-    }
+    public var alternativeName: String { Dipper.ALTERNATIVE_NAMES[index] }
+    public var westernName: String { Dipper.WESTERN_NAMES[index] }
+    public var position: String { Dipper.POSITIONS[index] }
+    public var brightnessRank: Int { Dipper.BRIGHTNESS_RANK[index] }
+    public var number: Int { index + 1 }
 
     /// Check if this star is part of the bowl (斗魁)
-    /// - Returns: true if part of bowl
-    public func isBowl() -> Bool {
-        return Dipper.POSITIONS[index] == "斗魁"
-    }
+    public func isBowl() -> Bool { Dipper.POSITIONS[index] == "斗魁" }
 
     /// Check if this star is part of the handle (斗柄)
-    /// - Returns: true if part of handle
-    public func isHandle() -> Bool {
-        return Dipper.POSITIONS[index] == "斗柄"
-    }
+    public func isHandle() -> Bool { Dipper.POSITIONS[index] == "斗柄" }
 
-    /// Get brightness ranking (1 = brightest)
-    /// - Returns: Brightness rank
-    public func getBrightnessRank() -> Int {
-        return Dipper.BRIGHTNESS_RANK[index]
-    }
+    @available(*, deprecated, renamed: "alternativeName")
+    public func getAlternativeName() -> String { alternativeName }
 
-    /// Get star number (序号)
-    /// - Returns: Star number (1-7)
-    public func getNumber() -> Int {
-        return index + 1
-    }
+    @available(*, deprecated, renamed: "westernName")
+    public func getWesternName() -> String { westernName }
+
+    @available(*, deprecated, renamed: "position")
+    public func getPosition() -> String { position }
+
+    @available(*, deprecated, renamed: "brightnessRank")
+    public func getBrightnessRank() -> Int { brightnessRank }
+
+    @available(*, deprecated, renamed: "number")
+    public func getNumber() -> Int { number }
 }

--- a/Sources/tyme/star/NineDay.swift
+++ b/Sources/tyme/star/NineDay.swift
@@ -73,27 +73,20 @@ public final class NineDay: LoopTyme {
 
     // MARK: - Properties
 
-    /// Get palace number
-    /// - Returns: Palace number (1-9)
-    public func getNumber() -> Int {
-        return NineDay.NUMBERS[index]
-    }
+    public var number: Int { NineDay.NUMBERS[index] }
+    public var direction: String { NineDay.DIRECTIONS[index] }
+    public var wuXing: String { NineDay.WU_XING[index] }
+    public var nineStar: NineStar { NineStar.fromIndex(index) }
 
-    /// Get direction
-    /// - Returns: Direction name
-    public func getDirection() -> String {
-        return NineDay.DIRECTIONS[index]
-    }
+    @available(*, deprecated, renamed: "number")
+    public func getNumber() -> Int { number }
 
-    /// Get WuXing (五行)
-    /// - Returns: Element (金, 木, 水, 火, 土)
-    public func getWuXing() -> String {
-        return NineDay.WU_XING[index]
-    }
+    @available(*, deprecated, renamed: "direction")
+    public func getDirection() -> String { direction }
 
-    /// Get corresponding NineStar
-    /// - Returns: NineStar instance
-    public func getNineStar() -> NineStar {
-        return NineStar.fromIndex(index)
-    }
+    @available(*, deprecated, renamed: "wuXing")
+    public func getWuXing() -> String { wuXing }
+
+    @available(*, deprecated, renamed: "nineStar")
+    public func getNineStar() -> NineStar { nineStar }
 }

--- a/Sources/tyme/star/NineStar.swift
+++ b/Sources/tyme/star/NineStar.swift
@@ -95,85 +95,58 @@ public final class NineStar: LoopTyme {
 
     // MARK: - Properties
 
-    /// Get full name with celestial name
-    /// - Returns: Full star name (e.g., "一白贪狼")
-    public func getFullName() -> String {
-        return NineStar.FULL_NAMES[index]
-    }
-
-    /// Get celestial name
-    /// - Returns: Celestial name (e.g., "贪狼")
-    public func getCelestialName() -> String {
-        return NineStar.CELESTIAL_NAMES[index]
-    }
-
-    /// Get YinYang
-    /// - Returns: YinYang (阳 or 阴)
-    public func getYinYang() -> String {
-        return NineStar.YIN_YANG[index]
-    }
-
-    /// Get WuXing (五行)
-    /// - Returns: Element (金, 木, 水, 火, 土)
-    public func getWuXing() -> String {
-        return NineStar.WU_XING[index]
-    }
-
-    /// Get Element instance
-    /// - Returns: Element instance
-    public func getElement() -> Element {
-        return try! Element.fromName(NineStar.WU_XING[index])
-    }
-
-    /// Get direction
-    /// - Returns: Direction name
-    public func getDirection() -> String {
-        return NineStar.DIRECTIONS[index]
-    }
-
-    /// Get Direction instance
-    /// - Returns: Direction instance (nil for center)
-    public func getDirectionInstance() -> Direction? {
+    public var fullName: String { NineStar.FULL_NAMES[index] }
+    public var celestialName: String { NineStar.CELESTIAL_NAMES[index] }
+    public var yinYang: String { NineStar.YIN_YANG[index] }
+    public var wuXing: String { NineStar.WU_XING[index] }
+    public var element: Element { try! Element.fromName(NineStar.WU_XING[index]) }
+    public var direction: String { NineStar.DIRECTIONS[index] }
+    public var directionInstance: Direction? {
         let dir = NineStar.DIRECTIONS[index]
-        if dir == "中" {
-            return nil
-        }
+        if dir == "中" { return nil }
         return try! Direction.fromName(dir)
     }
-
-    /// Get Bagua (八卦)
-    /// - Returns: Bagua name
-    public func getBagua() -> String {
-        return NineStar.BAGUA[index]
-    }
-
-    /// Get color
-    /// - Returns: Color name
-    public func getColor() -> String {
-        return NineStar.COLORS[index]
-    }
-
-    /// Get luck (吉凶)
-    /// - Returns: Luck (吉, 凶, or 中)
-    public func getLuck() -> String {
-        return NineStar.LUCK[index]
-    }
+    public var bagua: String { NineStar.BAGUA[index] }
+    public var color: String { NineStar.COLORS[index] }
+    public var luck: String { NineStar.LUCK[index] }
+    public var number: Int { index + 1 }
 
     /// Check if this is an auspicious star
-    /// - Returns: true if auspicious
-    public func isAuspicious() -> Bool {
-        return NineStar.LUCK[index] == "吉"
-    }
+    public func isAuspicious() -> Bool { NineStar.LUCK[index] == "吉" }
 
     /// Check if this is an inauspicious star
-    /// - Returns: true if inauspicious
-    public func isInauspicious() -> Bool {
-        return NineStar.LUCK[index] == "凶"
-    }
+    public func isInauspicious() -> Bool { NineStar.LUCK[index] == "凶" }
 
-    /// Get number (数字)
-    /// - Returns: Star number (1-9)
-    public func getNumber() -> Int {
-        return index + 1
-    }
+    @available(*, deprecated, renamed: "fullName")
+    public func getFullName() -> String { fullName }
+
+    @available(*, deprecated, renamed: "celestialName")
+    public func getCelestialName() -> String { celestialName }
+
+    @available(*, deprecated, renamed: "yinYang")
+    public func getYinYang() -> String { yinYang }
+
+    @available(*, deprecated, renamed: "wuXing")
+    public func getWuXing() -> String { wuXing }
+
+    @available(*, deprecated, renamed: "element")
+    public func getElement() -> Element { element }
+
+    @available(*, deprecated, renamed: "direction")
+    public func getDirection() -> String { direction }
+
+    @available(*, deprecated, renamed: "directionInstance")
+    public func getDirectionInstance() -> Direction? { directionInstance }
+
+    @available(*, deprecated, renamed: "bagua")
+    public func getBagua() -> String { bagua }
+
+    @available(*, deprecated, renamed: "color")
+    public func getColor() -> String { color }
+
+    @available(*, deprecated, renamed: "luck")
+    public func getLuck() -> String { luck }
+
+    @available(*, deprecated, renamed: "number")
+    public func getNumber() -> Int { number }
 }

--- a/Sources/tyme/star/seven/SevenStar.swift
+++ b/Sources/tyme/star/seven/SevenStar.swift
@@ -46,9 +46,8 @@ public final class SevenStar: LoopTyme {
         return SevenStar.fromIndex(nextIndex(n))
     }
 
-    /// Get corresponding Week day
-    /// - Returns: Week instance
-    public func getWeek() -> Week {
-        return Week.fromIndex(index)
-    }
+    public var week: Week { Week.fromIndex(index) }
+
+    @available(*, deprecated, renamed: "week")
+    public func getWeek() -> Week { week }
 }

--- a/Sources/tyme/star/twelve/Ecliptic.swift
+++ b/Sources/tyme/star/twelve/Ecliptic.swift
@@ -44,21 +44,14 @@ public final class Ecliptic: LoopTyme {
         return Ecliptic.fromIndex(nextIndex(n))
     }
 
-    /// Get luck (吉凶)
-    /// - Returns: Luck instance (黄道=吉, 黑道=凶)
-    public func getLuck() -> Luck {
-        return Luck.fromIndex(index)
-    }
+    public var luck: Luck { Luck.fromIndex(index) }
 
     /// Check if auspicious (黄道)
-    /// - Returns: true if 黄道
-    public func isAuspicious() -> Bool {
-        return index == 0
-    }
+    public func isAuspicious() -> Bool { index == 0 }
 
     /// Check if inauspicious (黑道)
-    /// - Returns: true if 黑道
-    public func isInauspicious() -> Bool {
-        return index == 1
-    }
+    public func isInauspicious() -> Bool { index == 1 }
+
+    @available(*, deprecated, renamed: "luck")
+    public func getLuck() -> Luck { luck }
 }

--- a/Sources/tyme/star/twelve/TwelveStar.swift
+++ b/Sources/tyme/star/twelve/TwelveStar.swift
@@ -49,21 +49,14 @@ public final class TwelveStar: LoopTyme {
         return TwelveStar.fromIndex(nextIndex(n))
     }
 
-    /// Get ecliptic (黄道黑道)
-    /// - Returns: Ecliptic instance
-    public func getEcliptic() -> Ecliptic {
-        return Ecliptic.fromIndex(TwelveStar.ECLIPTIC_INDICES[index])
-    }
+    public var ecliptic: Ecliptic { Ecliptic.fromIndex(TwelveStar.ECLIPTIC_INDICES[index]) }
 
     /// Check if auspicious (黄道)
-    /// - Returns: true if 黄道
-    public func isAuspicious() -> Bool {
-        return TwelveStar.ECLIPTIC_INDICES[index] == 0
-    }
+    public func isAuspicious() -> Bool { TwelveStar.ECLIPTIC_INDICES[index] == 0 }
 
     /// Check if inauspicious (黑道)
-    /// - Returns: true if 黑道
-    public func isInauspicious() -> Bool {
-        return TwelveStar.ECLIPTIC_INDICES[index] == 1
-    }
+    public func isInauspicious() -> Bool { TwelveStar.ECLIPTIC_INDICES[index] == 1 }
+
+    @available(*, deprecated, renamed: "ecliptic")
+    public func getEcliptic() -> Ecliptic { ecliptic }
 }

--- a/Sources/tyme/star/twentyeight/TwentyEightStar.swift
+++ b/Sources/tyme/star/twentyeight/TwentyEightStar.swift
@@ -52,45 +52,30 @@ public final class TwentyEightStar: LoopTyme {
         return TwentyEightStar.fromIndex(nextIndex(n))
     }
 
-    /// Get SevenStar (七曜)
-    /// - Returns: SevenStar instance
-    public func getSevenStar() -> SevenStar {
-        return SevenStar.fromIndex(index % 7 + 4)
-    }
-
-    /// Get Land (九野)
-    /// - Returns: Land instance
-    public func getLand() -> Land {
-        return Land.fromIndex(TwentyEightStar.LAND_INDICES[index])
-    }
-
-    /// Get Zone (宫)
-    /// - Returns: Zone instance
-    public func getZone() -> Zone {
-        return Zone.fromIndex(index / 7)
-    }
-
-    /// Get Animal (动物)
-    /// - Returns: Animal instance
-    public func getAnimal() -> Animal {
-        return Animal.fromIndex(index)
-    }
-
-    /// Get Luck (吉凶)
-    /// - Returns: Luck instance
-    public func getLuck() -> Luck {
-        return Luck.fromIndex(TwentyEightStar.LUCK_INDICES[index])
-    }
+    public var sevenStar: SevenStar { SevenStar.fromIndex(index % 7 + 4) }
+    public var land: Land { Land.fromIndex(TwentyEightStar.LAND_INDICES[index]) }
+    public var zone: Zone { Zone.fromIndex(index / 7) }
+    public var animal: Animal { Animal.fromIndex(index) }
+    public var luck: Luck { Luck.fromIndex(TwentyEightStar.LUCK_INDICES[index]) }
 
     /// Check if auspicious
-    /// - Returns: true if 吉
-    public func isAuspicious() -> Bool {
-        return TwentyEightStar.LUCK_INDICES[index] == 0
-    }
+    public func isAuspicious() -> Bool { TwentyEightStar.LUCK_INDICES[index] == 0 }
 
     /// Check if inauspicious
-    /// - Returns: true if 凶
-    public func isInauspicious() -> Bool {
-        return TwentyEightStar.LUCK_INDICES[index] == 1
-    }
+    public func isInauspicious() -> Bool { TwentyEightStar.LUCK_INDICES[index] == 1 }
+
+    @available(*, deprecated, renamed: "sevenStar")
+    public func getSevenStar() -> SevenStar { sevenStar }
+
+    @available(*, deprecated, renamed: "land")
+    public func getLand() -> Land { land }
+
+    @available(*, deprecated, renamed: "zone")
+    public func getZone() -> Zone { zone }
+
+    @available(*, deprecated, renamed: "animal")
+    public func getAnimal() -> Animal { animal }
+
+    @available(*, deprecated, renamed: "luck")
+    public func getLuck() -> Luck { luck }
 }

--- a/Sources/tyme/tibetan/RabByung.swift
+++ b/Sources/tyme/tibetan/RabByung.swift
@@ -45,35 +45,22 @@ public final class RabByung: LoopTyme {
     }
 
     /// Get RabByung from index
-    /// - Parameter index: RabByung index (0-59)
-    /// - Returns: RabByung instance
-    public static func fromIndex(_ index: Int) -> RabByung {
-        return RabByung(index: index)
-    }
+    public static func fromIndex(_ index: Int) -> RabByung { RabByung(index: index) }
 
     /// Get RabByung from name
-    /// - Parameter name: RabByung name (e.g., "火兔", "土龙", etc.)
-    /// - Returns: RabByung instance
-    public static func fromName(_ name: String) throws -> RabByung {
-        return try RabByung(name: name)
-    }
+    public static func fromName(_ name: String) throws -> RabByung { try RabByung(name: name) }
 
-    /// Get next RabByung
-    /// - Parameter n: Number of steps to advance
-    /// - Returns: Next RabByung instance
-    public override func next(_ n: Int) -> RabByung {
-        return RabByung.fromIndex(nextIndex(n))
-    }
+    public override func next(_ n: Int) -> RabByung { RabByung.fromIndex(nextIndex(n)) }
 
-    /// Get element (五行)
-    /// - Returns: Element name
-    public func getElement() -> String {
-        return RabByung.ELEMENTS[(index / 2) % 5]
-    }
+    /// The element (五行)
+    public var element: String { RabByung.ELEMENTS[(index / 2) % 5] }
 
-    /// Get animal (生肖)
-    /// - Returns: Animal name
-    public func getAnimal() -> String {
-        return RabByung.ANIMALS[index % 12]
-    }
+    /// The animal (生肖)
+    public var animal: String { RabByung.ANIMALS[index % 12] }
+
+    @available(*, deprecated, renamed: "element")
+    public func getElement() -> String { element }
+
+    @available(*, deprecated, renamed: "animal")
+    public func getAnimal() -> String { animal }
 }

--- a/Sources/tyme/tibetan/RabByungElement.swift
+++ b/Sources/tyme/tibetan/RabByungElement.swift
@@ -7,7 +7,7 @@ public final class RabByungElement: AbstractCulture {
     public static let NAMES = ["木", "火", "土", "铁", "水"]
 
     /// Internal element (uses standard Element)
-    private let element: Element
+    public let element: Element
 
     /// Initialize with index
     /// - Parameter index: Element index (0-4)
@@ -26,62 +26,51 @@ public final class RabByungElement: AbstractCulture {
     }
 
     /// Create from index
-    /// - Parameter index: Element index
-    /// - Returns: RabByungElement instance
-    public static func fromIndex(_ index: Int) throws -> RabByungElement {
-        return try RabByungElement(index: index)
-    }
+    public static func fromIndex(_ index: Int) throws -> RabByungElement { try RabByungElement(index: index) }
 
     /// Create from name
-    /// - Parameter name: Element name
-    /// - Returns: RabByungElement instance
-    public static func fromName(_ name: String) throws -> RabByungElement {
-        return try RabByungElement(name: name)
-    }
+    public static func fromName(_ name: String) throws -> RabByungElement { try RabByungElement(name: name) }
 
     /// Get element name (金→铁)
-    /// - Returns: Element name with 铁 instead of 金
     public override func getName() -> String {
         return element.getName().replacingOccurrences(of: "金", with: "铁")
     }
 
-    /// Get element index
-    /// - Returns: Element index (0-4)
-    public func getIndex() -> Int {
-        return element.getIndex()
-    }
+    /// The element index
+    public var index: Int { element.index }
 
     /// Get next element in cycle
-    /// - Parameter n: Steps to advance (can be negative)
-    /// - Returns: Next RabByungElement
     public func next(_ n: Int) -> RabByungElement {
         let nextElement = element.next(n)
-        return try! RabByungElement(index: nextElement.getIndex())
+        return try! RabByungElement(index: nextElement.index)
     }
 
     // MARK: - Five Elements Relationships (五行生克)
 
-    /// Get element that this generates (我生者)
-    /// - Returns: Element I reinforce
-    public func getReinforce() -> RabByungElement {
-        return next(1)
-    }
+    /// The element that this generates (我生者)
+    public var reinforce: RabByungElement { next(1) }
 
-    /// Get element that this restrains (我克者)
-    /// - Returns: Element I restrain
-    public func getRestrain() -> RabByungElement {
-        return next(2)
-    }
+    /// The element that this restrains (我克者)
+    public var restrain: RabByungElement { next(2) }
 
-    /// Get element that generates this (生我者)
-    /// - Returns: Element that reinforces me
-    public func getReinforced() -> RabByungElement {
-        return next(-1)
-    }
+    /// The element that generates this (生我者)
+    public var reinforced: RabByungElement { next(-1) }
 
-    /// Get element that restrains this (克我者)
-    /// - Returns: Element that restrains me
-    public func getRestrained() -> RabByungElement {
-        return next(-2)
-    }
+    /// The element that restrains this (克我者)
+    public var restrained: RabByungElement { next(-2) }
+
+    @available(*, deprecated, renamed: "index")
+    public func getIndex() -> Int { index }
+
+    @available(*, deprecated, renamed: "reinforce")
+    public func getReinforce() -> RabByungElement { reinforce }
+
+    @available(*, deprecated, renamed: "restrain")
+    public func getRestrain() -> RabByungElement { restrain }
+
+    @available(*, deprecated, renamed: "reinforced")
+    public func getReinforced() -> RabByungElement { reinforced }
+
+    @available(*, deprecated, renamed: "restrained")
+    public func getRestrained() -> RabByungElement { restrained }
 }

--- a/Sources/tyme/tibetan/TibetanDay.swift
+++ b/Sources/tyme/tibetan/TibetanDay.swift
@@ -13,10 +13,10 @@ public final class TibetanDay: AbstractCulture {
         "廿六", "廿七", "廿八", "廿九", "三十"
     ]
 
-    private let year: Int
-    private let month: Int
-    private let day: Int
-    private let isLeapMonth: Bool
+    public let year: Int
+    public let month: Int
+    public let day: Int
+    public let isLeapMonth: Bool
 
     /// Initialize with year, month, and day
     /// - Parameters:
@@ -31,52 +31,16 @@ public final class TibetanDay: AbstractCulture {
         super.init()
     }
 
-    /// Get year
-    /// - Returns: Year value
-    public func getYear() -> Int {
-        return year
-    }
+    public var monthWithLeap: Int { isLeapMonth ? -month : month }
 
-    /// Get month
-    /// - Returns: Month value (1-12)
-    public func getMonth() -> Int {
-        return month
-    }
+    public var tibetanMonth: TibetanMonth { TibetanMonth.fromYm(year, monthWithLeap) }
 
-    /// Get day
-    /// - Returns: Day value (1-30)
-    public func getDay() -> Int {
-        return day
-    }
-
-    /// Check if in leap month
-    /// - Returns: true if in leap month
-    public func isInLeapMonth() -> Bool {
-        return isLeapMonth
-    }
-
-    /// Get month with leap indicator
-    /// - Returns: Month value (negative for leap)
-    public func getMonthWithLeap() -> Int {
-        return isLeapMonth ? -month : month
-    }
+    public var tibetanYear: TibetanYear { TibetanYear.fromYear(year) }
 
     /// Get name
     /// - Returns: Day name
     public override func getName() -> String {
         return TibetanDay.NAMES[day - 1]
-    }
-
-    /// Get Tibetan month
-    /// - Returns: TibetanMonth instance
-    public func getTibetanMonth() -> TibetanMonth {
-        return try! TibetanMonth.fromYm(year, getMonthWithLeap())
-    }
-
-    /// Get Tibetan year
-    /// - Returns: TibetanYear instance
-    public func getTibetanYear() -> TibetanYear {
-        return TibetanYear.fromYear(year)
     }
 
     /// Get next Tibetan day
@@ -109,12 +73,28 @@ public final class TibetanDay: AbstractCulture {
     }
 
     /// Create from year, month, and day
-    /// - Parameters:
-    ///   - year: The year
-    ///   - month: The month (1-12, negative for leap)
-    ///   - day: The day (1-30)
-    /// - Returns: TibetanDay instance
     public static func fromYmd(_ year: Int, _ month: Int, _ day: Int) -> TibetanDay {
         return TibetanDay(year: year, month: month, day: day)
     }
+
+    @available(*, deprecated, renamed: "year")
+    public func getYear() -> Int { year }
+
+    @available(*, deprecated, renamed: "month")
+    public func getMonth() -> Int { month }
+
+    @available(*, deprecated, renamed: "day")
+    public func getDay() -> Int { day }
+
+    @available(*, deprecated, renamed: "isLeapMonth")
+    public func isInLeapMonth() -> Bool { isLeapMonth }
+
+    @available(*, deprecated, renamed: "monthWithLeap")
+    public func getMonthWithLeap() -> Int { monthWithLeap }
+
+    @available(*, deprecated, renamed: "tibetanMonth")
+    public func getTibetanMonth() -> TibetanMonth { tibetanMonth }
+
+    @available(*, deprecated, renamed: "tibetanYear")
+    public func getTibetanYear() -> TibetanYear { tibetanYear }
 }

--- a/Sources/tyme/tibetan/TibetanMonth.swift
+++ b/Sources/tyme/tibetan/TibetanMonth.swift
@@ -9,9 +9,9 @@ public final class TibetanMonth: AbstractCulture {
         "具醉月", "具贤月", "天降月", "持众月", "庄严月", "满意月"
     ]
 
-    private let year: Int
-    private let month: Int
-    private let isLeap: Bool
+    public let year: Int
+    public let month: Int
+    public let isLeap: Bool
 
     /// Initialize with year and month
     /// - Parameters:
@@ -24,41 +24,15 @@ public final class TibetanMonth: AbstractCulture {
         super.init()
     }
 
-    /// Get year
-    /// - Returns: Year value
-    public func getYear() -> Int {
-        return year
-    }
+    public var monthWithLeap: Int { isLeap ? -month : month }
 
-    /// Get month
-    /// - Returns: Month value (1-12)
-    public func getMonth() -> Int {
-        return month
-    }
-
-    /// Check if leap month
-    /// - Returns: true if leap month
-    public func isLeapMonth() -> Bool {
-        return isLeap
-    }
-
-    /// Get month with leap indicator
-    /// - Returns: Month value (negative for leap)
-    public func getMonthWithLeap() -> Int {
-        return isLeap ? -month : month
-    }
+    public var tibetanYear: TibetanYear { TibetanYear.fromYear(year) }
 
     /// Get name
     /// - Returns: Month name
     public override func getName() -> String {
         let prefix = isLeap ? "闰" : ""
         return prefix + TibetanMonth.NAMES[month - 1]
-    }
-
-    /// Get Tibetan year
-    /// - Returns: TibetanYear instance
-    public func getTibetanYear() -> TibetanYear {
-        return TibetanYear.fromYear(year)
     }
 
     /// Get next Tibetan month
@@ -86,4 +60,19 @@ public final class TibetanMonth: AbstractCulture {
     public static func fromYm(_ year: Int, _ month: Int) -> TibetanMonth {
         return TibetanMonth(year: year, month: month)
     }
+
+    @available(*, deprecated, renamed: "year")
+    public func getYear() -> Int { year }
+
+    @available(*, deprecated, renamed: "month")
+    public func getMonth() -> Int { month }
+
+    @available(*, deprecated, renamed: "isLeap")
+    public func isLeapMonth() -> Bool { isLeap }
+
+    @available(*, deprecated, renamed: "monthWithLeap")
+    public func getMonthWithLeap() -> Int { monthWithLeap }
+
+    @available(*, deprecated, renamed: "tibetanYear")
+    public func getTibetanYear() -> TibetanYear { tibetanYear }
 }

--- a/Sources/tyme/tibetan/TibetanYear.swift
+++ b/Sources/tyme/tibetan/TibetanYear.swift
@@ -6,9 +6,9 @@ public final class TibetanYear: AbstractCulture {
     /// The first RabByung cycle started in 1027 CE
     public static let FIRST_RABBYUNG_YEAR = 1027
 
-    private let year: Int
-    private let rabByungCycle: Int
-    private let rabByungIndex: Int
+    public let year: Int
+    public let rabByungCycle: Int
+    public let rabByungIndex: Int
 
     /// Initialize with year
     /// - Parameter year: The year in Gregorian calendar
@@ -31,53 +31,23 @@ public final class TibetanYear: AbstractCulture {
         super.init()
     }
 
-    /// Get year
-    /// - Returns: Year value
-    public func getYear() -> Int {
-        return year
-    }
+    public var rabByung: RabByung { RabByung.fromIndex(rabByungIndex) }
 
-    /// Get RabByung cycle number
-    /// - Returns: Cycle number (1-based)
-    public func getRabByungCycle() -> Int {
-        return rabByungCycle
-    }
+    public var element: String { rabByung.element }
 
-    /// Get RabByung index within cycle
-    /// - Returns: Index (0-59)
-    public func getRabByungIndex() -> Int {
-        return rabByungIndex
-    }
-
-    /// Get RabByung
-    /// - Returns: RabByung instance
-    public func getRabByung() -> RabByung {
-        return RabByung.fromIndex(rabByungIndex)
-    }
+    public var animal: String { rabByung.animal }
 
     /// Get name
     /// - Returns: Tibetan year name (e.g., "第17绕迥火兔年")
     public override func getName() -> String {
-        return "第\(rabByungCycle)绕迥\(getRabByung().getName())年"
-    }
-
-    /// Get element (五行)
-    /// - Returns: Element name
-    public func getElement() -> String {
-        return getRabByung().getElement()
-    }
-
-    /// Get animal (生肖)
-    /// - Returns: Animal name
-    public func getAnimal() -> String {
-        return getRabByung().getAnimal()
+        return "第\(rabByungCycle)绕迥\(rabByung.getName())年"
     }
 
     /// Get next Tibetan year
     /// - Parameter n: Number of years to advance
     /// - Returns: Next TibetanYear instance
     public func next(_ n: Int) -> TibetanYear {
-        return try! TibetanYear(year: year + n)
+        return TibetanYear(year: year + n)
     }
 
     /// Create from year
@@ -86,4 +56,22 @@ public final class TibetanYear: AbstractCulture {
     public static func fromYear(_ year: Int) -> TibetanYear {
         return TibetanYear(year: year)
     }
+
+    @available(*, deprecated, renamed: "year")
+    public func getYear() -> Int { year }
+
+    @available(*, deprecated, renamed: "rabByungCycle")
+    public func getRabByungCycle() -> Int { rabByungCycle }
+
+    @available(*, deprecated, renamed: "rabByungIndex")
+    public func getRabByungIndex() -> Int { rabByungIndex }
+
+    @available(*, deprecated, renamed: "rabByung")
+    public func getRabByung() -> RabByung { rabByung }
+
+    @available(*, deprecated, renamed: "element")
+    public func getElement() -> String { element }
+
+    @available(*, deprecated, renamed: "animal")
+    public func getAnimal() -> String { animal }
 }


### PR DESCRIPTION
## Summary

- Add Swift computed properties to all `tibetan` module classes (RabByung, TibetanYear, TibetanMonth, TibetanDay, RabByungElement)
- Add Swift computed properties to all `star` module classes (NineStar, Dipper, NineDay, SevenStar, TwelveStar, TwentyEightStar, Ecliptic)
- Mark original `getXxx()` methods as `@available(*, deprecated, renamed: "xxx")` for backward compatibility
- Make stored properties `public` where previously `internal`/`private`
- All 114 tests passing

Part of #34