### PR TITLE
refactor: Add computed properties for solar/lunar modules

### DIFF
--- a/Sources/tyme/lunar/LunarDay.swift
+++ b/Sources/tyme/lunar/LunarDay.swift
@@ -3,12 +3,12 @@ import Foundation
 public final class LunarDay: DayUnit, Tyme {
     public static let NAMES = ["初一", "初二", "初三", "初四", "初五", "初六", "初七", "初八", "初九", "初十", "十一", "十二", "十三", "十四", "十五", "十六", "十七", "十八", "十九", "二十", "廿一", "廿二", "廿三", "廿四", "廿五", "廿六", "廿七", "廿八", "廿九", "三十"]
 
-    private let leap: Bool
+    public let leap: Bool
 
     public static func validate(year: Int, month: Int, day: Int) throws {
         if day < 1 { throw TymeError.invalidDay(day) }
         let m = try! LunarMonth.fromYm(year, month)
-        if day > m.getDayCount() { throw TymeError.invalidDay(day) }
+        if day > m.dayCount { throw TymeError.invalidDay(day) }
     }
 
     public override init(year: Int, month: Int, day: Int) throws {
@@ -17,46 +17,59 @@ public final class LunarDay: DayUnit, Tyme {
         try super.init(year: year, month: abs(month), day: day)
     }
 
-    public override func getMonth() -> Int { leap ? -super.getMonth() : super.getMonth() }
+    /// Returns signed month (negative if leap month)
+    public var monthWithLeap: Int { leap ? -month : month }
 
     public static func fromYmd(_ year: Int, _ month: Int, _ day: Int) throws -> LunarDay {
         try LunarDay(year: year, month: month, day: day)
     }
 
-    public func getLunarMonth() -> LunarMonth { try! LunarMonth.fromYm(getYear(), try! getMonth()) }
+    public var lunarMonth: LunarMonth { try! LunarMonth.fromYm(year, monthWithLeap) }
 
-    public func getName() -> String { LunarDay.NAMES[getDay() - 1] }
+    public func getName() -> String { LunarDay.NAMES[day - 1] }
 
-    public func next(_ n: Int) -> LunarDay {
-        getSolarDay().next(n).getLunarDay()
-    }
+    public func next(_ n: Int) -> LunarDay { solarDay.next(n).lunarDay }
 
     public func isBefore(_ target: LunarDay) -> Bool {
-        if getYear() != target.getYear() { return getYear() < target.getYear() }
-        if getMonth() != target.getMonth() { return abs(getMonth()) < abs(target.getMonth()) }
-        return getDay() < target.getDay()
+        if year != target.year { return year < target.year }
+        if monthWithLeap != target.monthWithLeap { return abs(monthWithLeap) < abs(target.monthWithLeap) }
+        return day < target.day
     }
 
     public func isAfter(_ target: LunarDay) -> Bool {
-        if getYear() != target.getYear() { return getYear() > target.getYear() }
-        if getMonth() != target.getMonth() { return abs(getMonth()) >= abs(target.getMonth()) }
-        return getDay() > target.getDay()
+        if year != target.year { return year > target.year }
+        if monthWithLeap != target.monthWithLeap { return abs(monthWithLeap) >= abs(target.monthWithLeap) }
+        return day > target.day
     }
 
-    public func getWeek() -> Week { try! getSolarDay().getWeek() }
-
-    public func getSixtyCycle() -> SixtyCycle {
-        let offset = Int(getLunarMonth().getFirstJulianDay().next(getDay() - 12).getDay())
+    public var week: Week { solarDay.week }
+    public var sixtyCycle: SixtyCycle {
+        let offset = Int(lunarMonth.firstJulianDay.next(day - 12).value)
         let stem = HeavenStem.fromIndex(offset).getName()
         let branch = EarthBranch.fromIndex(offset).getName()
         return try! SixtyCycle.fromName(stem + branch)
     }
-
-    public func getSolarDay() -> SolarDay {
-        try! getLunarMonth().getFirstJulianDay().next(getDay() - 1).getSolarDay()
+    public var solarDay: SolarDay {
+        lunarMonth.firstJulianDay.next(day - 1).solarDay
     }
+    public var fetusDay: FetusDay { FetusDay.fromLunarDay(self) }
 
-    public func getFetusDay() -> FetusDay {
-        FetusDay.fromLunarDay(self)
-    }
+    /// Deprecated override — use `monthWithLeap` instead
+    @available(*, deprecated, renamed: "monthWithLeap")
+    public override func getMonth() -> Int { monthWithLeap }
+
+    @available(*, deprecated, renamed: "lunarMonth")
+    public func getLunarMonth() -> LunarMonth { lunarMonth }
+
+    @available(*, deprecated, renamed: "week")
+    public func getWeek() -> Week { week }
+
+    @available(*, deprecated, renamed: "sixtyCycle")
+    public func getSixtyCycle() -> SixtyCycle { sixtyCycle }
+
+    @available(*, deprecated, renamed: "solarDay")
+    public func getSolarDay() -> SolarDay { solarDay }
+
+    @available(*, deprecated, renamed: "fetusDay")
+    public func getFetusDay() -> FetusDay { fetusDay }
 }

--- a/Sources/tyme/lunar/LunarHour.swift
+++ b/Sources/tyme/lunar/LunarHour.swift
@@ -15,61 +15,72 @@ public final class LunarHour: SecondUnit, Tyme {
         try LunarHour(year: year, month: month, day: day, hour: hour, minute: minute, second: second)
     }
 
-    public func getLunarDay() -> LunarDay { try! LunarDay.fromYmd(getYear(), try! getMonth(), getDay()) }
+    public var lunarDay: LunarDay { try! LunarDay.fromYmd(year, month, day) }
+    public var indexInDay: Int { (hour + 1) / 2 }
 
-    public func getName() -> String { EarthBranch.fromIndex(getIndexInDay()).getName() + "时" }
+    public func getName() -> String { EarthBranch.fromIndex(indexInDay).getName() + "时" }
 
-    public func getIndexInDay() -> Int { (getHour() + 1) / 2 }
-
-    public func next(_ n: Int) -> LunarHour {
-        if n == 0 { return try! LunarHour.fromYmdHms(getYear(), getMonth(), getDay(), getHour(), getMinute(), getSecond()) }
-        var h = getHour() + n * 2
-        let diff = h < 0 ? -1 : 1
-        var hour = abs(h)
-        var days = hour / 24 * diff
-        hour = (hour % 24) * diff
-        if hour < 0 {
-            hour += 24
-            days -= 1
-        }
-        let d = getLunarDay().next(days)
-        return try! LunarHour.fromYmdHms(d.getYear(), d.getMonth(), d.getDay(), hour, getMinute(), getSecond())
-    }
-
-    public func isBefore(_ target: LunarHour) -> Bool {
-        let d = getLunarDay()
-        let td = target.getLunarDay()
-        if d.getYear() != td.getYear() || d.getMonth() != td.getMonth() || d.getDay() != td.getDay() {
-            return d.isBefore(td)
-        }
-        if getHour() != target.getHour() { return getHour() < target.getHour() }
-        if getMinute() != target.getMinute() { return getMinute() < target.getMinute() }
-        return getSecond() < target.getSecond()
-    }
-
-    public func isAfter(_ target: LunarHour) -> Bool {
-        let d = getLunarDay()
-        let td = target.getLunarDay()
-        if d.getYear() != td.getYear() || d.getMonth() != td.getMonth() || d.getDay() != td.getDay() {
-            return d.isAfter(td)
-        }
-        if getHour() != target.getHour() { return getHour() > target.getHour() }
-        if getMinute() != target.getMinute() { return getMinute() > target.getMinute() }
-        return getSecond() > target.getSecond()
-    }
-
-    public func getSixtyCycle() -> SixtyCycle {
-        let earthBranchIndex = try! getIndexInDay() % 12
-        var d = getLunarDay().getSixtyCycle()
-        if getHour() >= 23 { d = d.next(1) }
-        let stemIndex = d.getHeavenStem().getIndex() % 5 * 2 + earthBranchIndex
+    public var sixtyCycle: SixtyCycle {
+        let earthBranchIndex = indexInDay % 12
+        var d = lunarDay.sixtyCycle
+        if hour >= 23 { d = d.next(1) }
+        let stemIndex = d.getHeavenStem().index % 5 * 2 + earthBranchIndex
         let stem = HeavenStem.fromIndex(stemIndex).getName()
         let branch = EarthBranch.fromIndex(earthBranchIndex).getName()
         return try! SixtyCycle.fromName(stem + branch)
     }
 
-    public func getSolarTime() -> SolarTime {
-        let d = try! getLunarDay().getSolarDay()
-        return try! SolarTime.fromYmdHms(d.getYear(), d.getMonth(), d.getDay(), getHour(), getMinute(), getSecond())
+    public var solarTime: SolarTime {
+        let d = lunarDay.solarDay
+        return try! SolarTime.fromYmdHms(d.year, d.month, d.day, hour, minute, second)
     }
+
+    public func next(_ n: Int) -> LunarHour {
+        if n == 0 { return try! LunarHour.fromYmdHms(year, month, day, hour, minute, second) }
+        let h = hour + n * 2
+        let diff = h < 0 ? -1 : 1
+        var newHour = abs(h)
+        var days = newHour / 24 * diff
+        newHour = (newHour % 24) * diff
+        if newHour < 0 {
+            newHour += 24
+            days -= 1
+        }
+        let d = lunarDay.next(days)
+        return try! LunarHour.fromYmdHms(d.year, d.monthWithLeap, d.day, newHour, minute, second)
+    }
+
+    public func isBefore(_ target: LunarHour) -> Bool {
+        let d = lunarDay
+        let td = target.lunarDay
+        if d.year != td.year || d.monthWithLeap != td.monthWithLeap || d.day != td.day {
+            return d.isBefore(td)
+        }
+        if hour != target.hour { return hour < target.hour }
+        if minute != target.minute { return minute < target.minute }
+        return second < target.second
+    }
+
+    public func isAfter(_ target: LunarHour) -> Bool {
+        let d = lunarDay
+        let td = target.lunarDay
+        if d.year != td.year || d.monthWithLeap != td.monthWithLeap || d.day != td.day {
+            return d.isAfter(td)
+        }
+        if hour != target.hour { return hour > target.hour }
+        if minute != target.minute { return minute > target.minute }
+        return second > target.second
+    }
+
+    @available(*, deprecated, renamed: "lunarDay")
+    public func getLunarDay() -> LunarDay { lunarDay }
+
+    @available(*, deprecated, renamed: "indexInDay")
+    public func getIndexInDay() -> Int { indexInDay }
+
+    @available(*, deprecated, renamed: "sixtyCycle")
+    public func getSixtyCycle() -> SixtyCycle { sixtyCycle }
+
+    @available(*, deprecated, renamed: "solarTime")
+    public func getSolarTime() -> SolarTime { solarTime }
 }

--- a/Sources/tyme/lunar/LunarWeek.swift
+++ b/Sources/tyme/lunar/LunarWeek.swift
@@ -22,39 +22,48 @@ public final class LunarWeek: WeekUnit, Tyme {
         try LunarWeek(year: year, month: month, index: index, start: start)
     }
 
-    public func getLunarMonth() -> LunarMonth { try! LunarMonth.fromYm(year, month) }
+    public var lunarMonth: LunarMonth { try! LunarMonth.fromYm(year, month) }
 
     public func getName() -> String { LunarWeek.NAMES[index] }
 
     public func next(_ n: Int) -> LunarWeek {
         if n == 0 { return try! LunarWeek(year: year, month: month, index: index, start: startIndex) }
         var d = index + n
-        var m = getLunarMonth()
+        var m = lunarMonth
         if n > 0 {
             var weekCount = m.getWeekCount(startIndex)
             while d >= weekCount {
                 d -= weekCount
                 m = m.next(1)
-                if m.getFirstDay().getWeek().index != startIndex { d += 1 }
+                if m.firstDay.week.index != startIndex { d += 1 }
                 weekCount = m.getWeekCount(startIndex)
             }
         } else {
             while d < 0 {
-                if m.getFirstDay().getWeek().index != startIndex { d -= 1 }
+                if m.firstDay.week.index != startIndex { d -= 1 }
                 m = m.next(-1)
                 d += m.getWeekCount(startIndex)
             }
         }
-        return try! LunarWeek(year: m.year, month: m.getMonthWithLeap(), index: d, start: startIndex)
+        return try! LunarWeek(year: m.year, month: m.monthWithLeap, index: d, start: startIndex)
     }
 
-    public func getFirstDay() -> LunarDay {
-        let firstDay = try! LunarDay.fromYmd(year, month, 1)
-        return firstDay.next(index * 7 - indexOf(firstDay.getWeek().index - startIndex, 7))
+    public var firstDay: LunarDay {
+        let fd = try! LunarDay.fromYmd(year, month, 1)
+        return fd.next(index * 7 - indexOf(fd.week.index - startIndex, 7))
     }
 
-    public func getDays() -> [LunarDay] {
-        let d = getFirstDay()
+    public var days: [LunarDay] {
+        let d = firstDay
         return (0..<7).map { d.next($0) }
     }
+
+    @available(*, deprecated, renamed: "lunarMonth")
+    public func getLunarMonth() -> LunarMonth { lunarMonth }
+
+    @available(*, deprecated, renamed: "firstDay")
+    public func getFirstDay() -> LunarDay { firstDay }
+
+    @available(*, deprecated, renamed: "days")
+    public func getDays() -> [LunarDay] { days }
 }

--- a/Sources/tyme/lunar/LunarYear.swift
+++ b/Sources/tyme/lunar/LunarYear.swift
@@ -9,7 +9,7 @@ public final class LunarYear: YearUnit, Tyme {
         "0z0j0j0j0C0j0j0C0j0j0j0C0j0C0j0j0j0j0m0j0C0j0j0C0j0j0j0j0b0V0j0j0C0j0j0j0j0V0j0j0j0V0b0V0V0C0V0C0j0j0b080u110u0V0C0j0N0j0b080b080b0j0r0b0r0b0j0j0j0j0C0j0b0r0C0j0b0j0C0C0j0j0j0j0j0j0j0j0j0b110j0b0j0j0j0C0j0C0j0j0j0j0b080b080b0V080b080b0j0j0j0j0j0j0V0j0j0u1v0j0j0j0C0j0j0j0V0C0N1c0j0C0C0j0j0j1n080b0j0V0C0j0C0C2g0j1c0j0j1v2g1v0j0j1v7N0j1c0j3L0j0j1v5Q1Z5Q1v4lfn1v420j1v5Q1Z5Q1v4l1v2z1v",
         "0H140r0N0r140r0u0r0V171c11140C0j0u110j0u0j1v0j0C0j0j0j0b080V0u080b0C1v0j0j0j0C0j0b080V0j0j0b080b0j0j0j0j0b080b0C080j0b080b0j0j0j0j0j0j0b080j0b080C0b080b080b080b0j0j0j0j080b0j0C0j0j0j0b0j0j080C0b0j0j0j0j0j0j0b08080b0j0C0j0j0j0b0j0j0K0b0j0C0j0j0j0b080b080j0C0b0j080b080b0j0j0j0j080b0j0b0r0j0j0j0b0j0C0r0b0j0j0j0j0j0j0j0b080j0b0r0C0j0b0j0j0j0r0b0j0C0j0j0j0u0r0b0C0j080b0j0j0j0j0j0j0j1c0j0b0j0j0j0C0j0j0j0j0j0j0j0b080j1c0u0j0j0j0C0j1c0j0u0j1c0j0j0j0j0j0j0j0j1c0j0u1v0j0j0V0j0j2g0j0j0j0C1v0C1G0j0j0V0C1Z1O0j0V0j0j2g1v0j0j0V0C2g5x1v4l1v421O7N0V0C4l1v2S1c0j1v2S2_",
         "050b080C0j0j0j0C0j0j0C0j0j0j0C0j0C0j0C030j0j0j0j0j0j0j0j0j0C0j0b080u0V080b0j0j0V0j0j0j0j0j0j0j0j0j0V0N0j0C0C0j0j0j0j0j0j0j0j1c0j0u0j1v0j0j0j0j0j0b080b080j0j0j0b080b080b080b080b0j0j0j080b0j0b080j0j0j0j0b080b0j0j0r0b080b0b080j0j0j0j0b080b080j0b080j0b080b080b080b080b0j0j0r0b0j0b080j0j0j0j0b080b0j0j0C080b0b080j0j0j0j0j0j0j0b080u080j0j0b0j0j0j0C0j0b080j0j0j0j0b080b080b080b0C080b080b080b0j0j0j0j0j0j0b0C080j0j0b0j0j0j0C0j0b080j0j0C0b080b080j0b0j0j0C080b0j0j0j0j0j0j0b0j0j080C0b0j080b0j0j0j0j0j0j0j0C0j0j0j0b0j0j0C080b0j0j0j0j0j0j0b080b080b0K0b080b080b0j0j0j0j0j0j0j0C0j0j0u0j0j0V0j080b0j0C0j0j0j0b0j0r0C0b0j0j0j0j0j0j0j0j0j0C0j0b080b080b0j0C0C0j0C0j0j0j0u110u0j0j0j0j0j0j0j0j0C0j0j0u0j1c0j0j0j0j0j0j0j0j0V0C0u0j0C0C0V0C1Z0j0j0j0C0j0j0j1v0u0j1c0j0j0j0C0j0j2g0j1c1v0C1Z0V0j4l0j0V0j0j2g0j1v0j1v2S1c7N1v",
-        "0w0j1c0j0V0j0j0V0V0V0j0m0V0j0C1c140j0j0j0C0V0C0j1v0j0N0j0C0j0j0j0V0j0j1v0N0j0j0V0j0j0j0j0j0j080b0j0j0j0j0j0j0j080b0j0C0j0j0j0b0j0j080u080b0j0j0j0j0j0j0b080b080b080C0b0j080b080b0j0j0j0j080b0j0C0j0j0j0b0j0j080u080b0j0j0j0j0j0j0b080b080b080b0r0b0j080b080b0j0j0j0j080b0j0b0r0j0j0b080b0j0j080b0j080b0j080b080b0j0j0j0j0j0b080b0r0C0b080b0j0j0j0j080b0b080b080j0j0j0b080b080b080b0j0j0j0j080b0j0b080j0j0j0j0b080b0j0j0r0b080b0j0j0j0j0j0b080b080j0b0r0b080j0b080b0j0j0j0j080b0j0b080j0j0j0j0b080b0j080b0r0b0j080b080b0j0j0j0j0j0b080b0r0C0b080b0j0j0j0j0j0j0b080j0j0j0b080b080b080b0j0j0j0r0b0j0b080j0j0j0j0b080b0r0b0r0b0j080b080b0j0j0j0j0j0j0b0r0j0j0j0b0j0j0j0j080b0j0b080j0j0j0j0b080b080b0j0r0b0j080b0j0j0j0j0j0j0j0b0r0C0b0j0j0j0j0j0j0j080b0j0C0j0j0j0b0j0C0r0b0j0j0j0j0j0j0b080b080u0r0b0j080b0j0j0j0j0j0j0j0b0r0C0u0j0j0j0C0j080b0j0C0j0j0j0u110b0j0j0j0j0j0j0j0j0j0C0j0b080b0j0j0C0C0j0C0j0j0j0b0j1c0j080b0j0j0j0j0j0j0V0j0j0u0j1c0j0j0j0C0j0j2g0j0j0j0C0j0j0V0j0b080b1c0C0V0j0j2g0j0j0V0j0j1c0j1Z0j0j0C0C0j1v",
+        "0w0j1c0j0V0j0j0V0V0V0j0m0V0j0C1c140j0j0j0C0V0C0j1v0j0N0j0C0j0j0j0V0j0j1v0N0j0j0V0j0j0j0j0j0j080b0j0j0j0j0j0j0j080b0j0C0j0j0j0b0j0j080u080b0j0j0j0j0j0j0b080b080b080C0b0j080b080b0j0j0j0j080b0j0C0j0j0j0b0j0j080u080b0j0j0j0j0j0j0b080b080b080b0r0b0j080b080b0j0j0j0j080b0j0b0r0j0j0b080b0j0j080b0j080b0j080b080b0j0j0j0j0j0b080b0r0C0b080b0j0j0j0j080b0b080b080j0j0j0b080b080b080b0j0j0j0j080b0j0b080j0j0j0j0b080b0j0j0r0b080b0j0j0j0j0j0b080b080j0b0r0b080j0b080b0j0j0j0j080b0j0b080j0j0j0j0b080b0j080b0r0b0j080b080b0j0j0j0j0j0b080b0r0C0b080b0j0j0j0j0j0j0b080j0j0j0b080b080b080b0j0j0j0r0b0j0b080j0j0j0j0b080b0r0b0r0b0j080b080b0j0j0j0j0j0j0b0r0C0j0b0j0j0j0j0j0j0b080j0C0j0b080j0b0j0j0K0b0j0C0j0j0j0b080b0j0K0b0j080b0j0j0j0j0j0j0V0j0j0b0j0j0j0C0j0j0j0j",
         "160j0j0V0j1c0j0C0j0C0j1f0j0V0C0j0j0C0j0j0j1G080b080u0V080b0j0j0V0j1v0j0u0j1c0j0j0j0C0j0j0j0C0C0j1D0b0j080b0j0j0j0j0C0j0b0r0C0j0b0j0C0C0j0j0j0j0j0j0j0j0j0b0r0b0r0j0b0j0j0j0C0j0b0r0j0j0j0b080b080j0b0C0j080b080b0j0j0j0j0j0j0b0C080j0j0b0j0j0j0C0j0b080j0j0j0j0b080b080j0b0C0r0j0b0j0j0j0j0j0j0b0C080j0j0b0j0j0j0C0j0j0j0j0C0j0j0b080b0j0j0C080b0j0j0j0j0j0j0b080b080b080C0b080b080b080b0j0j0j0j0j0b080C0j0j0b080b0j0j0C080b0j0j0j0j0j0j0b080j0b0C080j0j0b0j0j0j0j0j0j0b080j0b080C0b080b080b080b0j0j0j0j080b0j0C0j0j0b080b0j0j0C080b0j0j0j0j0j0j0b080j0b080u080j0j0b0j0j0j0j0j0j0b080C0j0j0b080b0j0j0C0j0j080b0j0j0j0j0j0b080b0C0r0b080b0j0j0j0j0j0j0b080j0b080u080b080b080b0j0j0j0C0j0b080j0j0j0j0b0j0j0j0C0j0j080b0j0j0j0j0j0b080b0C0r0b080b0j0j0j0j0j0j0b080j0b0r0b080b080b080b0j0j0j0r0b0j0b0r0j0j0j0b0j0j0j0r0b0j080b0j0j0j0j0j0j0j0b0r0C0b0j0j0j0j0j0j0j0b080j0C0u080b080b0j0j0j0r0b0j0C0C0j0b0j110b0j080b0j0j0j0j0j0j0u0r0C0b0j0j0j0j0j0j0j0j0j0C0j0j0j0b0j1c0j0C0j0j0j0b0j0814080b080b0j0j0j0j0j0j1c0j0u0j0j0V0j0j0j0j0j0j0j0u110u0j0j0j",
         "020b0r0C0j0j0j0C0j0j0V0j0j0j0j0j0C0j1f0j0C0j0V1G0j0j0j0j0V0C0j0C1v0u0j0j0j0V0j0j0C0j0j0j1v0N0C0V0j0j0j0K0C250b0C0V0j0j0V0j0j2g0C0V0j0j0C0j0j0b081v0N0j0j0V0V0j0j0u0j1c0j080b0j0j0j0j0j0j0V0j0j0u0j0j0V0j0j0j0C0j0b080b080V0b0j080b0j0j0j0j0j0j0j0b0r0C0j0b0j0j0j0C0j080b0j0j0j0j0j0j0u0r0C0u0j0j0j0j0j0j0b080j0C0j0b080b080b0j0C0j080b0j0j0j0j0j0j0b080b110b0j0j0j0j0j0j0j0j0j0b0r0j0j0j0b0j0j0j0r0b0j0b080j0j0j0j0b080b080b080b0r0b0j080b080b0j0j0j0j0j0j0b0r0C0b080b0j0j0j0j080b0j0b080j0j0j0j0b080b080b0j0j0j0r0b0j0j0j0j0j0j0b080b0j080C0b0j080b080b0j0j0j0j080b0j0b0r0C0b080b0j0j0j0j080b0j0j0j0j0j0b080b080b080b0j0j080b0r0b0j0j0j0j0j0j0b0j0j080C0b0j080b080b0j0j0j0j0j0b080C0j0j0b080b0j0j0C0j0b080j0j0j0j0b080b080b080b0C0C080b0j0j0j0j0j0j0b0C0C080b080b080b0j0j0j0j0j0j0b0C080j0j0b0j0j0j0C0j0b080j0b080j0j0b080b080b080b0C0r0b0j0j0j0j0j0j0b080b0r0b0r0b0j080b080b0j0j0j0j0j0j0b0r0C0j0b0j0j0j0j0j0j0b080j0C0j0b080j0b0j0j0K0b0j0C0j0j0j0b080b0j0K0b0j080b0j0j0j0j0j0j0V0j0j0b0j0j0j0C0j0j0j0j",
         "0l0C0K0N0r0N0j0r1G0V0m0j0V1c0C0j0j0j0j1O0N110u0j0j0j0C0j0j0V0C0j0u110u0j0j0j0C0j0j0j0C0C0j250j1c2S1v1v0j5x2g0j1c0j0j1c2z0j1c0j0j1c0j0N1v0V0C1v0C0b0C0V0j0j0C0j0C1v0u0j0C0C0j0j0j0C0j0j0j0u110u0j0j0j0C0j0C0C0C0b080b0j0C0j080b0j0C0j0j0j0u110u0j0j0j0C0j0j0j0C0j0j0j0u0C0r0u0j0j0j0j0j0j0b0r0b0V080b080b0j0C0j0j0j0V0j0j0b0j0j0j0C0j0j0j0j0j0j0j0b080j0b0C0r0j0b0j0j0j0C0j0b0r0b0r0j0b080b080b0j0C0j0j0j0j0j0j0j0j0b0j0C0r0b0j0j0j0j0j0j0b080b080j0b0r0b0r0j0b0j0j0j0j080b0j0b0r0j0j0j0b080b080b0j0j0j0j080b0j0j0j0j0j0j0b0j0j0j0r0b0j0j0j0j0j0j0b080b080b080b0r0C0b080b0j0j0j0j0j0b080b0r0C0b080b080b080b0j0j0j0j080b0j0C0j0j0j0b0j0j0C080b0j0j0j0j0j0j0b080j0b0C080j0j0b0j0j0j0j0j0j0b0r0b080j0j0b080b080b0j0j0j0j0j0j0b080j0j0j0j0b0j0j0j0r0b0j0b080j0j0j0j0j0b080b080b0C0r0b0j0j0j0j0j0j0b080b080j0C0b0j080b080b0j0j0j0j0j0j",
@@ -57,45 +57,46 @@ public final class LunarYear: YearUnit, Tyme {
         try LunarYear(year: year)
     }
 
-    public func getSixtyCycle() -> SixtyCycle {
-        SixtyCycle.fromIndex(getYear() - 4)
-    }
-
-    public func getDayCount() -> Int {
-        getMonths().reduce(0) { $0 + $1.getDayCount() }
-    }
-
-    public func getMonthCount() -> Int {
-        try! getLeapMonth() < 1 ? 12 : 13
-    }
-
-    public func getName() -> String {
-        "农历\(getSixtyCycle())年"
-    }
-
-    public func next(_ n: Int) -> LunarYear {
-        try! LunarYear(year: getYear() + n)
-    }
-
-    public func getLeapMonth() -> Int {
-        if try! getYear() == -1 { return 11 }
+    public var sixtyCycle: SixtyCycle { SixtyCycle.fromIndex(year - 4) }
+    public var leapMonth: Int {
+        if year == -1 { return 11 }
         for (i, years) in LunarYear.leapData.enumerated() {
-            if years.contains(getYear()) { return i + 1 }
+            if years.contains(year) { return i + 1 }
         }
         return 0
     }
-
-    public func getFirstMonth() -> LunarMonth {
-        try! LunarMonth(year: getYear(), month: 1)
-    }
-
-    public func getMonths() -> [LunarMonth] {
-        var months: [LunarMonth] = []
-        var m = try! getFirstMonth()
-        while m.getYear() == getYear() {
-            months.append(m)
+    public var monthCount: Int { leapMonth < 1 ? 12 : 13 }
+    public var dayCount: Int { months.reduce(0) { $0 + $1.dayCount } }
+    public var firstMonth: LunarMonth { try! LunarMonth(year: year, month: 1) }
+    public var months: [LunarMonth] {
+        var result: [LunarMonth] = []
+        var m = firstMonth
+        while m.year == year {
+            result.append(m)
             m = m.next(1)
         }
-        return months
+        return result
     }
+
+    public func getName() -> String { "农历\(sixtyCycle)年" }
+
+    public func next(_ n: Int) -> LunarYear { try! LunarYear(year: year + n) }
+
+    @available(*, deprecated, renamed: "sixtyCycle")
+    public func getSixtyCycle() -> SixtyCycle { sixtyCycle }
+
+    @available(*, deprecated, renamed: "leapMonth")
+    public func getLeapMonth() -> Int { leapMonth }
+
+    @available(*, deprecated, renamed: "monthCount")
+    public func getMonthCount() -> Int { monthCount }
+
+    @available(*, deprecated, renamed: "dayCount")
+    public func getDayCount() -> Int { dayCount }
+
+    @available(*, deprecated, renamed: "firstMonth")
+    public func getFirstMonth() -> LunarMonth { firstMonth }
+
+    @available(*, deprecated, renamed: "months")
+    public func getMonths() -> [LunarMonth] { months }
 }

--- a/Sources/tyme/solar/SolarHalfYear.swift
+++ b/Sources/tyme/solar/SolarHalfYear.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public final class SolarHalfYear: YearUnit, Tyme {
     public static let NAMES = ["上半年", "下半年"]
-    private let index: Int
+    public let index: Int
 
     public static func validate(year: Int, index: Int) throws {
         if index < 0 || index > 1 { throw TymeError.invalidIndex(index) }
@@ -19,22 +19,26 @@ public final class SolarHalfYear: YearUnit, Tyme {
         try SolarHalfYear(year: year, index: index)
     }
 
-    public func getSolarYear() -> SolarYear { try! SolarYear(year: getYear()) }
-
-    public func getIndex() -> Int { index }
+    public var solarYear: SolarYear { try! SolarYear(year: year) }
+    public var months: [SolarMonth] { (1...6).map { try! SolarMonth(year: year, month: index * 6 + $0) } }
+    public var seasons: [SolarSeason] { (0..<2).map { try! SolarSeason(year: year, index: index * 2 + $0) } }
 
     public func getName() -> String { SolarHalfYear.NAMES[index] }
 
     public func next(_ n: Int) -> SolarHalfYear {
         let i = index + n
-        return try! SolarHalfYear(year: (getYear() * 2 + i) / 2, index: indexOf(i, 2))
+        return try! SolarHalfYear(year: (year * 2 + i) / 2, index: indexOf(i, 2))
     }
 
-    public func getMonths() -> [SolarMonth] {
-        (1...6).map { try! SolarMonth(year: getYear(), month: index * 6 + $0) }
-    }
+    @available(*, deprecated, renamed: "solarYear")
+    public func getSolarYear() -> SolarYear { solarYear }
 
-    public func getSeasons() -> [SolarSeason] {
-        (0..<2).map { try! SolarSeason(year: getYear(), index: index * 2 + $0) }
-    }
+    @available(*, deprecated, renamed: "index")
+    public func getIndex() -> Int { index }
+
+    @available(*, deprecated, renamed: "months")
+    public func getMonths() -> [SolarMonth] { months }
+
+    @available(*, deprecated, renamed: "seasons")
+    public func getSeasons() -> [SolarSeason] { seasons }
 }

--- a/Sources/tyme/solar/SolarMonth.swift
+++ b/Sources/tyme/solar/SolarMonth.swift
@@ -6,37 +6,28 @@ public final class SolarMonth: MonthUnit, Tyme {
         try super.init(year: year, month: month)
     }
 
-    public static func fromYm(_ year: Int, _ month: Int)  throws -> SolarMonth {
+    public static func fromYm(_ year: Int, _ month: Int) throws -> SolarMonth {
         try SolarMonth(year: year, month: month)
     }
 
-    public func getName() -> String {
-        String(format: "%04d-%02d", try! getYear(), getMonth())
-    }
+    public func getName() -> String { String(format: "%04d-%02d", year, month) }
 
-    public func getDayCount() -> Int {
-        try! SolarUtil.daysInMonth(year: try! getYear(), month: getMonth())
-    }
-
-    public func getIndexInYear() -> Int { try! getMonth() - 1 }
-
-    public func getSeason() -> SolarSeason {
-        try! SolarSeason(year: getYear(), index: getIndexInYear() / 3)
-    }
+    public var dayCount: Int { try! SolarUtil.daysInMonth(year: year, month: month) }
+    public var indexInYear: Int { month - 1 }
+    public var season: SolarSeason { try! SolarSeason(year: year, index: indexInYear / 3) }
+    public var solarYear: SolarYear { try! SolarYear(year: year) }
+    public var days: [SolarDay] { (1...dayCount).map { try! SolarDay(year: year, month: month, day: $0) } }
+    public var firstDay: SolarDay { try! SolarDay(year: year, month: month, day: 1) }
 
     public func getWeekCount(_ start: Int) -> Int {
-        let firstWeekIndex = indexOf(getSolarDay(1).getWeek().getIndex() - start, 7)
-        return Int(ceil((Double(firstWeekIndex + getDayCount())) / 7.0))
+        let firstWeekIndex = indexOf(firstDay.week.index - start, 7)
+        return Int(ceil((Double(firstWeekIndex + dayCount)) / 7.0))
     }
 
-    public func getSolarDay(_ day: Int) -> SolarDay {
-        try! try SolarDay(year: getYear(), month: getMonth(), day: day)
-    }
-
-    public func getSolarYear() -> SolarYear { try! SolarYear(year: getYear()) }
+    public func getSolarDay(_ day: Int) -> SolarDay { try! SolarDay(year: year, month: month, day: day) }
 
     public func next(_ n: Int) -> SolarMonth {
-        let total = getYear() * 12 + (getMonth() - 1) + n
+        let total = year * 12 + (month - 1) + n
         let y = total / 12
         let m = indexOf(total, 12) + 1
         return try! SolarMonth(year: y, month: m)
@@ -44,12 +35,24 @@ public final class SolarMonth: MonthUnit, Tyme {
 
     public func getWeeks(_ start: Int) -> [SolarWeek] {
         let size = getWeekCount(start)
-        return (0..<size).map { try! SolarWeek(year: getYear(), month: getMonth(), index: $0, start: start) }
+        return (0..<size).map { try! SolarWeek(year: year, month: month, index: $0, start: start) }
     }
 
-    public func getDays() -> [SolarDay] {
-        (1...getDayCount()).map { try! try SolarDay(year: getYear(), month: getMonth(), day: $0) }
-    }
+    @available(*, deprecated, renamed: "dayCount")
+    public func getDayCount() -> Int { dayCount }
 
-    public func getFirstDay() -> SolarDay { try! try SolarDay(year: getYear(), month: getMonth(), day: 1) }
+    @available(*, deprecated, renamed: "indexInYear")
+    public func getIndexInYear() -> Int { indexInYear }
+
+    @available(*, deprecated, renamed: "season")
+    public func getSeason() -> SolarSeason { season }
+
+    @available(*, deprecated, renamed: "solarYear")
+    public func getSolarYear() -> SolarYear { solarYear }
+
+    @available(*, deprecated, renamed: "days")
+    public func getDays() -> [SolarDay] { days }
+
+    @available(*, deprecated, renamed: "firstDay")
+    public func getFirstDay() -> SolarDay { firstDay }
 }

--- a/Sources/tyme/solar/SolarSeason.swift
+++ b/Sources/tyme/solar/SolarSeason.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public final class SolarSeason: YearUnit, Tyme {
     public static let NAMES = ["一季度", "二季度", "三季度", "四季度"]
-    private let index: Int
+    public let index: Int
 
     public static func validate(year: Int, index: Int) throws {
         if index < 0 || index > 3 { throw TymeError.invalidIndex(index) }
@@ -19,18 +19,22 @@ public final class SolarSeason: YearUnit, Tyme {
         try SolarSeason(year: year, index: index)
     }
 
-    public func getSolarYear() -> SolarYear { try! SolarYear(year: getYear()) }
-
-    public func getIndex() -> Int { index }
+    public var solarYear: SolarYear { try! SolarYear(year: year) }
+    public var months: [SolarMonth] { (1...3).map { try! SolarMonth(year: year, month: index * 3 + $0) } }
 
     public func getName() -> String { SolarSeason.NAMES[index] }
 
     public func next(_ n: Int) -> SolarSeason {
         let i = index + n
-        return try! SolarSeason(year: (getYear() * 4 + i) / 4, index: indexOf(i, 4))
+        return try! SolarSeason(year: (year * 4 + i) / 4, index: indexOf(i, 4))
     }
 
-    public func getMonths() -> [SolarMonth] {
-        (1...3).map { try! SolarMonth(year: getYear(), month: index * 3 + $0) }
-    }
+    @available(*, deprecated, renamed: "solarYear")
+    public func getSolarYear() -> SolarYear { solarYear }
+
+    @available(*, deprecated, renamed: "index")
+    public func getIndex() -> Int { index }
+
+    @available(*, deprecated, renamed: "months")
+    public func getMonths() -> [SolarMonth] { months }
 }

--- a/Sources/tyme/solar/SolarTerm.swift
+++ b/Sources/tyme/solar/SolarTerm.swift
@@ -3,8 +3,8 @@ import Foundation
 public final class SolarTerm: LoopTyme {
     public static let NAMES = ["冬至", "小寒", "大寒", "立春", "雨水", "惊蛰", "春分", "清明", "谷雨", "立夏", "小满", "芒种", "夏至", "小暑", "大暑", "立秋", "处暑", "白露", "秋分", "寒露", "霜降", "立冬", "小雪", "大雪"]
 
-    private var year: Int
-    private var cursoryJulianDay: Double
+    public private(set) var year: Int
+    public private(set) var cursoryJulianDay: Double
 
     public required init(names: [String], index: Int) {
         self.year = 2000
@@ -54,14 +54,23 @@ public final class SolarTerm: LoopTyme {
     public func isJie() -> Bool { index % 2 == 1 }
     public func isQi() -> Bool { index % 2 == 0 }
 
-    public func getJulianDay() -> JulianDay {
+    public var julianDay: JulianDay {
         JulianDay.fromJulianDay(ShouXingUtil.qiAccurate2(cursoryJulianDay) + JulianDay.J2000)
     }
 
-    public func getSolarDay() -> SolarDay {
-        JulianDay.fromJulianDay(cursoryJulianDay + JulianDay.J2000).getSolarDay()
+    public var solarDay: SolarDay {
+        JulianDay.fromJulianDay(cursoryJulianDay + JulianDay.J2000).solarDay
     }
 
+    @available(*, deprecated, renamed: "year")
     public func getYear() -> Int { year }
+
+    @available(*, deprecated, renamed: "cursoryJulianDay")
     public func getCursoryJulianDay() -> Double { cursoryJulianDay }
+
+    @available(*, deprecated, renamed: "julianDay")
+    public func getJulianDay() -> JulianDay { julianDay }
+
+    @available(*, deprecated, renamed: "solarDay")
+    public func getSolarDay() -> SolarDay { solarDay }
 }

--- a/Sources/tyme/solar/SolarTermDay.swift
+++ b/Sources/tyme/solar/SolarTermDay.swift
@@ -5,7 +5,8 @@ public final class SolarTermDay: AbstractCultureDay {
         super.init(culture: solarTerm, dayIndex: dayIndex)
     }
 
-    public func getSolarTerm() -> SolarTerm {
-        culture as! SolarTerm
-    }
+    public var solarTerm: SolarTerm { culture as! SolarTerm }
+
+    @available(*, deprecated, renamed: "solarTerm")
+    public func getSolarTerm() -> SolarTerm { solarTerm }
 }

--- a/Sources/tyme/solar/SolarTime.swift
+++ b/Sources/tyme/solar/SolarTime.swift
@@ -11,66 +11,78 @@ public final class SolarTime: SecondUnit, Tyme {
     }
 
     public func getName() -> String {
-        String(format: "%04d-%02d-%02d %02d:%02d:%02d", try! getYear(), getMonth(), getDay(), getHour(), getMinute(), getSecond())
+        String(format: "%04d-%02d-%02d %02d:%02d:%02d", year, month, day, hour, minute, second)
     }
 
-    public func getJulianDay() -> JulianDay {
-        try! JulianDay.fromYmdHms(year: getYear(), month: getMonth(), day: getDay(), hour: getHour(), minute: getMinute(), second: getSecond())
+    public var julianDay: JulianDay {
+        try! JulianDay.fromYmdHms(year: year, month: month, day: day, hour: hour, minute: minute, second: second)
     }
 
-    public func getSolarDay() -> SolarDay { try! SolarDay(year: getYear(), month: getMonth(), day: getDay()) }
+    public var solarDay: SolarDay { try! SolarDay(year: year, month: month, day: day) }
+
+    public var lunarHour: LunarHour {
+        let d = solarDay.lunarDay
+        return try! LunarHour.fromYmdHms(d.year, d.monthWithLeap, d.day, hour, minute, second)
+    }
+
+    public var term: SolarTerm {
+        var t = solarDay.term
+        if isBefore(t.julianDay.solarTime) {
+            t = t.next(-1)
+        }
+        return t
+    }
 
     public func next(_ n: Int) -> SolarTime {
-        let jd = getJulianDay()
+        let jd = julianDay
         let target = JulianDay(jd.value + Double(n) / 86400.0)
         let ymd = target.toYmdHms()
         return try! SolarTime(year: ymd.year, month: ymd.month, day: ymd.day, hour: ymd.hour, minute: ymd.minute, second: ymd.second)
     }
 
     public func subtract(_ target: SolarTime) -> Int {
-        let days = getSolarDay().subtract(target.getSolarDay())
-        let cs = getHour() * 3600 + getMinute() * 60 + getSecond()
-        let ts = target.getHour() * 3600 + target.getMinute() * 60 + target.getSecond()
-        var seconds = cs - ts
+        let days = solarDay.subtract(target.solarDay)
+        let cs = hour * 3600 + minute * 60 + second
+        let ts = target.hour * 3600 + target.minute * 60 + target.second
+        var secs = cs - ts
         var d = days
-        if seconds < 0 {
-            seconds += 86400
+        if secs < 0 {
+            secs += 86400
             d -= 1
         }
-        seconds += d * 86400
-        return seconds
+        secs += d * 86400
+        return secs
     }
 
     public func isAfter(_ target: SolarTime) -> Bool {
-        let d = getSolarDay()
-        let td = target.getSolarDay()
-        if d.getYear() != td.getYear() || d.getMonth() != td.getMonth() || d.getDay() != td.getDay() {
+        let d = solarDay
+        let td = target.solarDay
+        if d.year != td.year || d.month != td.month || d.day != td.day {
             return d.isAfter(td)
         }
-        if getHour() != target.getHour() { return getHour() > target.getHour() }
-        return getMinute() != target.getMinute() ? getMinute() > target.getMinute() : getSecond() > target.getSecond()
+        if hour != target.hour { return hour > target.hour }
+        return minute != target.minute ? minute > target.minute : second > target.second
     }
 
     public func isBefore(_ target: SolarTime) -> Bool {
-        let d = getSolarDay()
-        let td = target.getSolarDay()
-        if d.getYear() != td.getYear() || d.getMonth() != td.getMonth() || d.getDay() != td.getDay() {
+        let d = solarDay
+        let td = target.solarDay
+        if d.year != td.year || d.month != td.month || d.day != td.day {
             return d.isBefore(td)
         }
-        if getHour() != target.getHour() { return getHour() < target.getHour() }
-        return getMinute() != target.getMinute() ? getMinute() < target.getMinute() : getSecond() < target.getSecond()
+        if hour != target.hour { return hour < target.hour }
+        return minute != target.minute ? minute < target.minute : second < target.second
     }
 
-    public func getLunarHour() -> LunarHour {
-        let d = try! getSolarDay().getLunarDay()
-        return try! LunarHour.fromYmdHms(d.getYear(), d.getMonth(), d.getDay(), getHour(), getMinute(), getSecond())
-    }
+    @available(*, deprecated, renamed: "julianDay")
+    public func getJulianDay() -> JulianDay { julianDay }
 
-    public func getTerm() -> SolarTerm {
-        var term = try! getSolarDay().getTerm()
-        if isBefore(term.getJulianDay().getSolarTime()) {
-            term = term.next(-1)
-        }
-        return term
-    }
+    @available(*, deprecated, renamed: "solarDay")
+    public func getSolarDay() -> SolarDay { solarDay }
+
+    @available(*, deprecated, renamed: "lunarHour")
+    public func getLunarHour() -> LunarHour { lunarHour }
+
+    @available(*, deprecated, renamed: "term")
+    public func getTerm() -> SolarTerm { term }
 }

--- a/Sources/tyme/solar/SolarWeek.swift
+++ b/Sources/tyme/solar/SolarWeek.swift
@@ -22,13 +22,13 @@ public final class SolarWeek: WeekUnit, Tyme {
         try SolarWeek(year: year, month: month, index: index, start: start)
     }
 
-    public func getSolarMonth() -> SolarMonth { try! SolarMonth(year: year, month: month) }
+    public var solarMonth: SolarMonth { try! SolarMonth(year: year, month: month) }
 
-    public func getIndexInYear() -> Int {
+    public var indexInYear: Int {
         var i = 0
-        let firstDay = getFirstDay()
+        let firstDay = self.firstDay
         var w = try! SolarWeek(year: year, month: 1, index: 0, start: startIndex)
-        while w.getFirstDay().getName() != firstDay.getName() {
+        while w.firstDay.getName() != firstDay.getName() {
             w = w.next(1)
             i += 1
         }
@@ -39,20 +39,20 @@ public final class SolarWeek: WeekUnit, Tyme {
 
     public func next(_ n: Int) -> SolarWeek {
         var d = index
-        var m = getSolarMonth()
+        var m = solarMonth
         if n > 0 {
             d += n
             var weekCount = m.getWeekCount(startIndex)
             while d >= weekCount {
                 d -= weekCount
                 m = m.next(1)
-                if m.getFirstDay().getWeek().index != startIndex { d += 1 }
+                if m.firstDay.week.index != startIndex { d += 1 }
                 weekCount = m.getWeekCount(startIndex)
             }
         } else if n < 0 {
             d += n
             while d < 0 {
-                if m.getFirstDay().getWeek().index != startIndex { d -= 1 }
+                if m.firstDay.week.index != startIndex { d -= 1 }
                 m = m.next(-1)
                 d += m.getWeekCount(startIndex)
             }
@@ -60,13 +60,25 @@ public final class SolarWeek: WeekUnit, Tyme {
         return try! SolarWeek(year: m.year, month: m.month, index: d, start: startIndex)
     }
 
-    public func getFirstDay() -> SolarDay {
-        let firstDay = try! SolarDay(year: year, month: month, day: 1)
-        return firstDay.next(index * 7 - indexOf(firstDay.getWeek().index - startIndex, 7))
+    public var firstDay: SolarDay {
+        let first = try! SolarDay(year: year, month: month, day: 1)
+        return first.next(index * 7 - indexOf(first.week.index - startIndex, 7))
     }
 
-    public func getDays() -> [SolarDay] {
-        let d = getFirstDay()
+    public var days: [SolarDay] {
+        let d = firstDay
         return (0..<7).map { d.next($0) }
     }
+
+    @available(*, deprecated, renamed: "solarMonth")
+    public func getSolarMonth() -> SolarMonth { solarMonth }
+
+    @available(*, deprecated, renamed: "indexInYear")
+    public func getIndexInYear() -> Int { indexInYear }
+
+    @available(*, deprecated, renamed: "firstDay")
+    public func getFirstDay() -> SolarDay { firstDay }
+
+    @available(*, deprecated, renamed: "days")
+    public func getDays() -> [SolarDay] { days }
 }

--- a/Sources/tyme/solar/SolarYear.swift
+++ b/Sources/tyme/solar/SolarYear.swift
@@ -10,28 +10,30 @@ public final class SolarYear: YearUnit, Tyme {
         try SolarYear(year: year)
     }
 
-    public func getName() -> String { String(format: "%04d", try! getYear()) }
+    public func getName() -> String { String(format: "%04d", year) }
 
-    public func getMonthCount() -> Int { 12 }
+    public var monthCount: Int { 12 }
+    public var dayCount: Int { year == 1582 ? 355 : SolarUtil.isLeapYear(year) ? 366 : 365 }
+    public var months: [SolarMonth] { (1...12).map { try! SolarMonth(year: year, month: $0) } }
+    public var seasons: [SolarSeason] { (0..<4).map { try! SolarSeason(year: year, index: $0) } }
+    public var halfYears: [SolarHalfYear] { (0..<2).map { try! SolarHalfYear(year: year, index: $0) } }
 
-    public func getDayCount() -> Int {
-        if try! getYear() == 1582 { return 355 }
-        return SolarUtil.isLeapYear(getYear()) ? 366 : 365
-    }
+    public func getSolarMonth(_ month: Int) -> SolarMonth { try! SolarMonth(year: year, month: month) }
 
-    public func getSolarMonth(_ month: Int) -> SolarMonth { try! SolarMonth(year: getYear(), month: month) }
+    public func next(_ n: Int) -> SolarYear { try! SolarYear(year: year + n) }
 
-    public func next(_ n: Int) -> SolarYear { try! SolarYear(year: getYear() + n) }
+    @available(*, deprecated, renamed: "monthCount")
+    public func getMonthCount() -> Int { monthCount }
 
-    public func getMonths() -> [SolarMonth] {
-        (1...12).map { try! SolarMonth(year: getYear(), month: $0) }
-    }
+    @available(*, deprecated, renamed: "dayCount")
+    public func getDayCount() -> Int { dayCount }
 
-    public func getSeasons() -> [SolarSeason] {
-        (0..<4).map { try! SolarSeason(year: getYear(), index: $0) }
-    }
+    @available(*, deprecated, renamed: "months")
+    public func getMonths() -> [SolarMonth] { months }
 
-    public func getHalfYears() -> [SolarHalfYear] {
-        (0..<2).map { try! SolarHalfYear(year: getYear(), index: $0) }
-    }
+    @available(*, deprecated, renamed: "seasons")
+    public func getSeasons() -> [SolarSeason] { seasons }
+
+    @available(*, deprecated, renamed: "halfYears")
+    public func getHalfYears() -> [SolarHalfYear] { halfYears }
 }


### PR DESCRIPTION
## Summary

- Convert no-arg `getXxx()` methods to Swift computed properties across solar and lunar modules (14 files)
- Add `@available(*, deprecated, renamed:)` annotations for backward compatibility
- Update internal calls to use new property names throughout

### Solar module (9 files)
- `SolarYear`: `monthCount`, `dayCount`, `months`, `seasons`, `halfYears`
- `SolarHalfYear`: `public let index`, `solarYear`, `months`, `seasons`
- `SolarSeason`: `public let index`, `solarYear`, `months`
- `SolarTermDay`: `solarTerm`
- `SolarTerm`: `public private(set) var year/cursoryJulianDay`, `julianDay`, `solarDay`
- `SolarMonth`: `dayCount`, `indexInYear`, `season`, `solarYear`, `days`, `firstDay`
- `SolarWeek`: `solarMonth`, `indexInYear`, `firstDay`, `days`
- `SolarDay`: `julianDay`, `solarMonth`, `solarYear`, `week`, `termDay`, `term`, `sixtyCycleDay`, `lunarDay`
- `SolarTime`: `julianDay`, `solarDay`, `lunarHour`, `term`

### Lunar module (5 files)
- `LunarYear`: `sixtyCycle`, `leapMonth`, `monthCount`, `dayCount`, `firstMonth`, `months`
- `LunarMonth`: `public let leap`, `monthWithLeap`, `lunarYear`, `indexInYear`, `season`, `firstJulianDay`, `dayCount`, `days`, `firstDay`, `fetus`
- `LunarDay`: `public let leap`, `monthWithLeap`, `lunarMonth`, `week`, `sixtyCycle`, `solarDay`, `fetusDay`
- `LunarHour`: `lunarDay`, `indexInDay`, `sixtyCycle`, `solarTime`
- `LunarWeek`: `lunarMonth`, `firstDay`, `days`

## Test plan
- [x] `swift build` — passes with only expected deprecation warnings from not-yet-migrated modules
- [x] `swift test` — all 114 tests pass

Part of #34