### PR TITLE
feat: Modernize eightchar module API (getXxx → computed properties)

### DIFF
--- a/Sources/tyme/eightchar/ChildLimit.swift
+++ b/Sources/tyme/eightchar/ChildLimit.swift
@@ -5,20 +5,20 @@ public final class ChildLimit {
     /// 童限计算接口
     public nonisolated(unsafe) static var provider: ChildLimitProvider = DefaultChildLimitProvider()
 
-    private let gender: Gender
-    private let forward: Bool
-    private let info: ChildLimitInfo
+    public let gender: Gender
+    public let forward: Bool
+    public let info: ChildLimitInfo
 
     public init(birthTime: SolarTime, gender: Gender) {
         self.gender = gender
         // 阳男阴女顺推，阴男阳女逆推
         let eightCharProvider = DefaultEightCharProvider()
-        let yearSixtyCycle = eightCharProvider.getYearSixtyCycle(year: birthTime.getYear(), month: birthTime.getMonth(), day: birthTime.getDay())
-        let yang = yearSixtyCycle.getHeavenStem().getIndex() % 2 == 0
+        let yearSixtyCycle = eightCharProvider.getYearSixtyCycle(year: birthTime.year, month: birthTime.month, day: birthTime.day)
+        let yang = yearSixtyCycle.heavenStem.index % 2 == 0
         let man = gender.isMale
         self.forward = (yang && man) || (!yang && !man)
 
-        var term = birthTime.getTerm()
+        var term = birthTime.term
         if !term.isJie() {
             term = term.next(-1)
         }
@@ -32,14 +32,32 @@ public final class ChildLimit {
         ChildLimit(birthTime: birthTime, gender: gender)
     }
 
+    public var yearCount: Int { info.yearCount }
+    public var monthCount: Int { info.monthCount }
+    public var dayCount: Int { info.dayCount }
+    public var hourCount: Int { info.hourCount }
+    public var minuteCount: Int { info.minuteCount }
+    public var startTime: SolarTime { info.startTime }
+    public var endTime: SolarTime { info.endTime }
+
+    @available(*, deprecated, renamed: "gender")
     public func getGender() -> Gender { gender }
+    @available(*, deprecated, renamed: "forward")
     public func isForward() -> Bool { forward }
-    public func getYearCount() -> Int { info.yearCount }
-    public func getMonthCount() -> Int { info.monthCount }
-    public func getDayCount() -> Int { info.dayCount }
-    public func getHourCount() -> Int { info.hourCount }
-    public func getMinuteCount() -> Int { info.minuteCount }
-    public func getStartTime() -> SolarTime { info.startTime }
-    public func getEndTime() -> SolarTime { info.endTime }
+    @available(*, deprecated, renamed: "yearCount")
+    public func getYearCount() -> Int { yearCount }
+    @available(*, deprecated, renamed: "monthCount")
+    public func getMonthCount() -> Int { monthCount }
+    @available(*, deprecated, renamed: "dayCount")
+    public func getDayCount() -> Int { dayCount }
+    @available(*, deprecated, renamed: "hourCount")
+    public func getHourCount() -> Int { hourCount }
+    @available(*, deprecated, renamed: "minuteCount")
+    public func getMinuteCount() -> Int { minuteCount }
+    @available(*, deprecated, renamed: "startTime")
+    public func getStartTime() -> SolarTime { startTime }
+    @available(*, deprecated, renamed: "endTime")
+    public func getEndTime() -> SolarTime { endTime }
+    @available(*, deprecated, renamed: "info")
     public func getInfo() -> ChildLimitInfo { info }
 }

--- a/Sources/tyme/eightchar/EightChar.swift
+++ b/Sources/tyme/eightchar/EightChar.swift
@@ -12,10 +12,10 @@ public final class EightChar {
     public let hourStem: HeavenStem
     public let hourBranch: EarthBranch
     
-    private let solarYear: Int
-    private let solarMonth: Int
-    private let solarDay: Int
-    private let solarHour: Int
+    public let solarYear: Int
+    public let solarMonth: Int
+    public let solarDay: Int
+    public let solarHour: Int
     
     /// 初始化八字
     /// - Parameters:
@@ -48,31 +48,28 @@ public final class EightChar {
         
         // Hour stem and branch (based on day stem and hour)
         let hourIndex = (hour + 1) / 2
-        self.hourStem = HeavenStem.fromIndex((yearStem.getIndex() * 2 + hourIndex) % 10)
+        self.hourStem = HeavenStem.fromIndex((yearStem.index * 2 + hourIndex) % 10)
         self.hourBranch = EarthBranch.fromIndex(hourIndex % 12)
     }
     
     // MARK: - Properties
     
-    public func getYearZodiac() -> String {
-        yearBranch.getZodiac()
-    }
-    
-    public func getSolarYear() -> Int {
-        solarYear
-    }
-    
-    public func getSolarMonth() -> Int {
-        solarMonth
-    }
-    
-    public func getSolarDay() -> Int {
-        solarDay
-    }
-    
-    public func getSolarHour() -> Int {
-        solarHour
-    }
+    public var yearZodiac: String { yearBranch.zodiac }
+
+    @available(*, deprecated, renamed: "yearZodiac")
+    public func getYearZodiac() -> String { yearZodiac }
+
+    @available(*, deprecated, renamed: "solarYear")
+    public func getSolarYear() -> Int { solarYear }
+
+    @available(*, deprecated, renamed: "solarMonth")
+    public func getSolarMonth() -> Int { solarMonth }
+
+    @available(*, deprecated, renamed: "solarDay")
+    public func getSolarDay() -> Int { solarDay }
+
+    @available(*, deprecated, renamed: "solarHour")
+    public func getSolarHour() -> Int { solarHour }
     
     public func getYearStemName() -> String {
         yearStem.getName()

--- a/Sources/tyme/eightchar/provider/ChildLimitProvider.swift
+++ b/Sources/tyme/eightchar/provider/ChildLimitProvider.swift
@@ -8,10 +8,10 @@ public protocol ChildLimitProvider {
 /// 童限计算抽象辅助方法
 extension ChildLimitProvider {
     func next(_ birthTime: SolarTime, _ addYear: Int, _ addMonth: Int, _ addDay: Int, _ addHour: Int, _ addMinute: Int, _ addSecond: Int) -> ChildLimitInfo {
-        var d = birthTime.getDay() + addDay
-        var h = birthTime.getHour() + addHour
-        var mi = birthTime.getMinute() + addMinute
-        var s = birthTime.getSecond() + addSecond
+        var d = birthTime.day + addDay
+        var h = birthTime.hour + addHour
+        var mi = birthTime.minute + addMinute
+        var s = birthTime.second + addSecond
         mi += s / 60
         s = s % 60
         h += mi / 60
@@ -19,18 +19,18 @@ extension ChildLimitProvider {
         d += h / 24
         h = h % 24
 
-        var sm = try! SolarMonth.fromYm(birthTime.getYear() + addYear, birthTime.getMonth()).next(addMonth)
+        var sm = try! SolarMonth.fromYm(birthTime.year + addYear, birthTime.month).next(addMonth)
 
-        var dc = sm.getDayCount()
+        var dc = sm.dayCount
         while d > dc {
             d -= dc
             sm = sm.next(1)
-            dc = sm.getDayCount()
+            dc = sm.dayCount
         }
 
         return ChildLimitInfo(
             startTime: birthTime,
-            endTime: try! SolarTime.fromYmdHms(sm.getYear(), sm.getMonth(), d, h, mi, s),
+            endTime: try! SolarTime.fromYmdHms(sm.year, sm.month, d, h, mi, s),
             yearCount: addYear,
             monthCount: addMonth,
             dayCount: addDay,

--- a/Sources/tyme/eightchar/provider/China95ChildLimitProvider.swift
+++ b/Sources/tyme/eightchar/provider/China95ChildLimitProvider.swift
@@ -6,7 +6,7 @@ public final class China95ChildLimitProvider: ChildLimitProvider {
 
     public func getInfo(birthTime: SolarTime, term: SolarTerm) -> ChildLimitInfo {
         // 出生时刻和节令时刻相差的分钟数
-        var minutes = abs(term.getJulianDay().getSolarTime().subtract(birthTime)) / 60
+        var minutes = abs(term.julianDay.solarTime.subtract(birthTime)) / 60
         let year = minutes / 4320
         minutes %= 4320
         let month = minutes / 360

--- a/Sources/tyme/eightchar/provider/DecadeFortuneProvider.swift
+++ b/Sources/tyme/eightchar/provider/DecadeFortuneProvider.swift
@@ -30,18 +30,17 @@ public struct DecadeFortuneInfo {
         self.endAge = endAge
     }
 
+    public var heavenStem: HeavenStem { sixtyCycle.heavenStem }
+    public var earthBranch: EarthBranch { sixtyCycle.earthBranch }
+
     /// Get name
     public func getName() -> String {
         return sixtyCycle.getName()
     }
 
-    /// Get heaven stem
-    public func getHeavenStem() -> HeavenStem {
-        return sixtyCycle.getHeavenStem()
-    }
+    @available(*, deprecated, renamed: "heavenStem")
+    public func getHeavenStem() -> HeavenStem { heavenStem }
 
-    /// Get earth branch
-    public func getEarthBranch() -> EarthBranch {
-        return sixtyCycle.getEarthBranch()
-    }
+    @available(*, deprecated, renamed: "earthBranch")
+    public func getEarthBranch() -> EarthBranch { earthBranch }
 }

--- a/Sources/tyme/eightchar/provider/DefaultChildLimitProvider.swift
+++ b/Sources/tyme/eightchar/provider/DefaultChildLimitProvider.swift
@@ -6,7 +6,7 @@ public final class DefaultChildLimitProvider: ChildLimitProvider {
 
     public func getInfo(birthTime: SolarTime, term: SolarTerm) -> ChildLimitInfo {
         // 出生时刻和节令时刻相差的秒数
-        var seconds = abs(term.getJulianDay().getSolarTime().subtract(birthTime))
+        var seconds = abs(term.julianDay.solarTime.subtract(birthTime))
         // 3天=259200秒=1年
         let year = seconds / 259200
         seconds %= 259200

--- a/Sources/tyme/eightchar/provider/DefaultDecadeFortuneProvider.swift
+++ b/Sources/tyme/eightchar/provider/DefaultDecadeFortuneProvider.swift
@@ -9,7 +9,7 @@ public final class DefaultDecadeFortuneProvider: DecadeFortuneProvider {
         let yearSixtyCycle = provider.getYearSixtyCycle(year: year, month: month, day: day)
         let monthSixtyCycle = provider.getMonthSixtyCycle(year: year, month: month, day: day)
 
-        let yearStemIndex = yearSixtyCycle.getHeavenStem().getIndex()
+        let yearStemIndex = yearSixtyCycle.heavenStem.index
         let isYangYear = yearStemIndex % 2 == 0
         let isMale = gender.isMale
         let isForward = (isYangYear && isMale) || (!isYangYear && !isMale)
@@ -17,7 +17,7 @@ public final class DefaultDecadeFortuneProvider: DecadeFortuneProvider {
         // Use ChildLimit to get start age
         let birthTime = try! SolarTime.fromYmdHms(year, month, day, hour, 0, 0)
         let childLimit = ChildLimit(birthTime: birthTime, gender: gender)
-        let startAge = childLimit.getYearCount()
+        let startAge = childLimit.yearCount
 
         var fortunes: [DecadeFortuneInfo] = []
         var currentSixtyCycle = monthSixtyCycle

--- a/Sources/tyme/eightchar/provider/DefaultEightCharProvider.swift
+++ b/Sources/tyme/eightchar/provider/DefaultEightCharProvider.swift
@@ -13,8 +13,8 @@ public final class DefaultEightCharProvider: EightCharProvider {
         var y = year
         // Before Lichun, use previous year
         let lichun = SolarTerm.fromIndex(y, 3) // 立春
-        let lichunDay = lichun.getSolarDay()
-        if month < lichunDay.getMonth() || (month == lichunDay.getMonth() && day < lichunDay.getDay()) {
+        let lichunDay = lichun.solarDay
+        if month < lichunDay.month || (month == lichunDay.month && day < lichunDay.day) {
             y -= 1
         }
         var index = (y - 4) % 60
@@ -27,7 +27,7 @@ public final class DefaultEightCharProvider: EightCharProvider {
     public func getMonthSixtyCycle(year: Int, month: Int, day: Int) -> SixtyCycle {
         // Get the year stem to calculate month stem
         let yearSixtyCycle = getYearSixtyCycle(year: year, month: month, day: day)
-        let yearStemIndex = yearSixtyCycle.getHeavenStem().getIndex()
+        let yearStemIndex = yearSixtyCycle.heavenStem.index
 
         // Determine which solar term month we're in
         var termMonth = month
@@ -35,8 +35,8 @@ public final class DefaultEightCharProvider: EightCharProvider {
         let jieIndex = (month - 1) * 2 + 3 // 立春=3, 惊蛰=5, etc.
         if jieIndex < 24 {
             let jie = SolarTerm.fromIndex(year, jieIndex)
-            let jieDay = jie.getSolarDay()
-            if day < jieDay.getDay() {
+            let jieDay = jie.solarDay
+            if day < jieDay.day {
                 termMonth = month - 1
                 if termMonth < 1 { termMonth = 12 }
             }
@@ -61,8 +61,8 @@ public final class DefaultEightCharProvider: EightCharProvider {
     /// Get day pillar SixtyCycle
     public func getDaySixtyCycle(year: Int, month: Int, day: Int) -> SixtyCycle {
         let solarDay = try! SolarDay.fromYmd(year, month, day)
-        let jd = solarDay.getJulianDay()
-        let offset = Int(jd.getDay() + 0.5) + 49
+        let jd = solarDay.julianDay
+        let offset = Int(jd.value + 0.5) + 49
         var index = offset % 60
         if index < 0 { index += 60 }
         return SixtyCycle.fromIndex(index)
@@ -79,7 +79,7 @@ public final class DefaultEightCharProvider: EightCharProvider {
         if hour >= 23 {
             daySixtyCycle = daySixtyCycle.next(1)
         }
-        let dayStemIndex = daySixtyCycle.getHeavenStem().getIndex()
+        let dayStemIndex = daySixtyCycle.heavenStem.index
 
         // Hour stem = (day stem % 5) * 2 + hour index
         let hourStemIndex = ((dayStemIndex % 5) * 2 + hourIndex) % 10

--- a/Sources/tyme/eightchar/provider/LunarEightCharProvider.swift
+++ b/Sources/tyme/eightchar/provider/LunarEightCharProvider.swift
@@ -9,8 +9,8 @@ public final class LunarEightCharProvider: EightCharProvider {
     public func getYearSixtyCycle(year: Int, month: Int, day: Int) -> SixtyCycle {
         // Get lunar day from solar day
         let solarDay = try! SolarDay.fromYmd(year, month, day)
-        let lunarDay = solarDay.getLunarDay()
-        let lunarYear = lunarDay.getLunarMonth().getLunarYear().getYear()
+        let lunarDay = solarDay.lunarDay
+        let lunarYear = lunarDay.lunarMonth.lunarYear.year
 
         // Year 4 is 甲子 (index 0)
         var index = (lunarYear - 4) % 60
@@ -22,15 +22,15 @@ public final class LunarEightCharProvider: EightCharProvider {
     public func getMonthSixtyCycle(year: Int, month: Int, day: Int) -> SixtyCycle {
         // Get lunar day from solar day
         let solarDay = try! SolarDay.fromYmd(year, month, day)
-        let lunarDay = solarDay.getLunarDay()
-        let lunarMonth = lunarDay.getLunarMonth()
+        let lunarDay = solarDay.lunarDay
+        let lunarMonth = lunarDay.lunarMonth
 
         // Get year stem
         let yearSixtyCycle = getYearSixtyCycle(year: year, month: month, day: day)
-        let yearStemIndex = yearSixtyCycle.getHeavenStem().getIndex()
+        let yearStemIndex = yearSixtyCycle.heavenStem.index
 
         // Month branch: 寅月(1月)=2, 卯月(2月)=3, etc.
-        let monthBranchIndex = (lunarMonth.getMonth() + 1) % 12
+        let monthBranchIndex = (lunarMonth.month + 1) % 12
 
         // Month stem = (year stem % 5) * 2 + month branch
         let monthStemIndex = ((yearStemIndex % 5) * 2 + monthBranchIndex) % 10
@@ -48,8 +48,8 @@ public final class LunarEightCharProvider: EightCharProvider {
     /// Get day pillar SixtyCycle
     public func getDaySixtyCycle(year: Int, month: Int, day: Int) -> SixtyCycle {
         let solarDay = try! SolarDay.fromYmd(year, month, day)
-        let jd = solarDay.getJulianDay()
-        let offset = Int(jd.getDay() + 0.5) + 49
+        let jd = solarDay.julianDay
+        let offset = Int(jd.value + 0.5) + 49
         var index = offset % 60
         if index < 0 { index += 60 }
         return SixtyCycle.fromIndex(index)
@@ -66,7 +66,7 @@ public final class LunarEightCharProvider: EightCharProvider {
         if hour >= 23 {
             daySixtyCycle = daySixtyCycle.next(1)
         }
-        let dayStemIndex = daySixtyCycle.getHeavenStem().getIndex()
+        let dayStemIndex = daySixtyCycle.heavenStem.index
 
         // Hour stem = (day stem % 5) * 2 + hour index
         let hourStemIndex = ((dayStemIndex % 5) * 2 + hourIndex) % 10

--- a/Sources/tyme/eightchar/provider/LunarSect1ChildLimitProvider.swift
+++ b/Sources/tyme/eightchar/provider/LunarSect1ChildLimitProvider.swift
@@ -5,19 +5,19 @@ public final class LunarSect1ChildLimitProvider: ChildLimitProvider {
     public init() {}
 
     public func getInfo(birthTime: SolarTime, term: SolarTerm) -> ChildLimitInfo {
-        let termTime = term.getJulianDay().getSolarTime()
+        let termTime = term.julianDay.solarTime
         var end = termTime
         var start = birthTime
         if birthTime.isAfter(termTime) {
             end = birthTime
             start = termTime
         }
-        let endTimeZhiIndex = end.getHour() == 23 ? 11 : (end.getHour() + 1) / 2
-        let startTimeZhiIndex = start.getHour() == 23 ? 11 : (start.getHour() + 1) / 2
+        let endTimeZhiIndex = end.hour == 23 ? 11 : (end.hour + 1) / 2
+        let startTimeZhiIndex = start.hour == 23 ? 11 : (start.hour + 1) / 2
         // 时辰差
         var hourDiff = endTimeZhiIndex - startTimeZhiIndex
         // 天数差
-        var dayDiff = end.getSolarDay().subtract(start.getSolarDay())
+        var dayDiff = end.solarDay.subtract(start.solarDay)
         if hourDiff < 0 {
             hourDiff += 12
             dayDiff -= 1

--- a/Sources/tyme/eightchar/provider/LunarSect2ChildLimitProvider.swift
+++ b/Sources/tyme/eightchar/provider/LunarSect2ChildLimitProvider.swift
@@ -6,7 +6,7 @@ public final class LunarSect2ChildLimitProvider: ChildLimitProvider {
 
     public func getInfo(birthTime: SolarTime, term: SolarTerm) -> ChildLimitInfo {
         // 出生时刻和节令时刻相差的分钟数
-        var minutes = abs(term.getJulianDay().getSolarTime().subtract(birthTime)) / 60
+        var minutes = abs(term.julianDay.solarTime.subtract(birthTime)) / 60
         let year = minutes / 4320
         minutes %= 4320
         let month = minutes / 360

--- a/Tests/tymeTests/EightCharTests.swift
+++ b/Tests/tymeTests/EightCharTests.swift
@@ -25,8 +25,8 @@ import Testing
 
         // Test year pillar
         let yearSixtyCycle = provider.getYearSixtyCycle(year: 2024, month: 2, day: 10)
-        _ = yearSixtyCycle.getHeavenStem()
-        _ = yearSixtyCycle.getEarthBranch()
+        _ = yearSixtyCycle.heavenStem
+        _ = yearSixtyCycle.earthBranch
 
         // Test month pillar
         _ = provider.getMonthSixtyCycle(year: 2024, month: 2, day: 10)
@@ -40,52 +40,52 @@ import Testing
     @Test func testChildLimitDefault() throws {
         // Verify ChildLimit creation and structural correctness
         let cl1 = ChildLimit.fromSolarTime(try SolarTime.fromYmdHms(2022, 3, 9, 20, 51, 0), .male)
-        #expect(cl1.getYearCount() >= 0)
-        #expect(cl1.getMonthCount() >= 0)
-        #expect(cl1.getDayCount() >= 0)
-        #expect(cl1.isForward()) // 壬寅年, Yang stem + Male = forward
+        #expect(cl1.yearCount >= 0)
+        #expect(cl1.monthCount >= 0)
+        #expect(cl1.dayCount >= 0)
+        #expect(cl1.forward) // 壬寅年, Yang stem + Male = forward
         // EndTime should be after birth time
-        #expect(cl1.getEndTime().isAfter(cl1.getStartTime()))
+        #expect(cl1.endTime.isAfter(cl1.startTime))
 
         // Female, Yang year = backward
         let cl2 = ChildLimit.fromSolarTime(try SolarTime.fromYmdHms(2022, 3, 9, 20, 51, 0), .female)
-        #expect(!cl2.isForward())
-        #expect(cl2.getEndTime().isAfter(cl2.getStartTime()))
+        #expect(!cl2.forward)
+        #expect(cl2.endTime.isAfter(cl2.startTime))
 
         // Verify different providers give different results
         let cl3 = ChildLimit.fromSolarTime(try SolarTime.fromYmdHms(1986, 5, 29, 13, 37, 0), .male)
-        #expect(cl3.getYearCount() >= 0)
-        #expect(cl3.getEndTime().isAfter(cl3.getStartTime()))
+        #expect(cl3.yearCount >= 0)
+        #expect(cl3.endTime.isAfter(cl3.startTime))
     }
     @Test func testChildLimitChina95() throws {
         ChildLimit.provider = China95ChildLimitProvider()
         let cl = ChildLimit.fromSolarTime(try SolarTime.fromYmdHms(1986, 5, 29, 13, 37, 0), .male)
         // China95 uses minute-based calculation, verify non-negative results
-        #expect(cl.getYearCount() >= 0)
-        #expect(cl.getMonthCount() >= 0)
-        #expect(cl.getHourCount() == 0) // China95 always has 0 hours
-        #expect(cl.getMinuteCount() == 0) // China95 always has 0 minutes
-        #expect(cl.getEndTime().isAfter(cl.getStartTime()))
+        #expect(cl.yearCount >= 0)
+        #expect(cl.monthCount >= 0)
+        #expect(cl.hourCount == 0) // China95 always has 0 hours
+        #expect(cl.minuteCount == 0) // China95 always has 0 minutes
+        #expect(cl.endTime.isAfter(cl.startTime))
         ChildLimit.provider = DefaultChildLimitProvider()
     }
     @Test func testChildLimitLunarSect1() throws {
         ChildLimit.provider = LunarSect1ChildLimitProvider()
         let cl = ChildLimit.fromSolarTime(try SolarTime.fromYmdHms(1994, 10, 17, 1, 0, 0), .male)
         // LunarSect1 uses day/hour-based calculation
-        #expect(cl.getYearCount() >= 0)
-        #expect(cl.getHourCount() == 0) // LunarSect1 always has 0 hours
-        #expect(cl.getMinuteCount() == 0) // LunarSect1 always has 0 minutes
-        #expect(cl.getEndTime().isAfter(cl.getStartTime()))
+        #expect(cl.yearCount >= 0)
+        #expect(cl.hourCount == 0) // LunarSect1 always has 0 hours
+        #expect(cl.minuteCount == 0) // LunarSect1 always has 0 minutes
+        #expect(cl.endTime.isAfter(cl.startTime))
         ChildLimit.provider = DefaultChildLimitProvider()
     }
     @Test func testChildLimitLunarSect2() throws {
         ChildLimit.provider = LunarSect2ChildLimitProvider()
         let cl = ChildLimit.fromSolarTime(try SolarTime.fromYmdHms(1986, 5, 29, 13, 37, 0), .male)
         // LunarSect2 uses minute-based calculation with hour component
-        #expect(cl.getYearCount() >= 0)
-        #expect(cl.getMonthCount() >= 0)
-        #expect(cl.getMinuteCount() == 0) // LunarSect2 always has 0 minutes
-        #expect(cl.getEndTime().isAfter(cl.getStartTime()))
+        #expect(cl.yearCount >= 0)
+        #expect(cl.monthCount >= 0)
+        #expect(cl.minuteCount == 0) // LunarSect2 always has 0 minutes
+        #expect(cl.endTime.isAfter(cl.startTime))
         ChildLimit.provider = DefaultChildLimitProvider()
     }
     @Test func testChildLimitProviderSwitch() throws {
@@ -107,9 +107,9 @@ import Testing
         // Different providers should generally give different results
         // (they use different conversion formulas)
         #expect(
-            defaultResult.getEndTime().getName() != china95Result.getEndTime().getName() ||
-            defaultResult.getEndTime().getName() != sect1Result.getEndTime().getName() ||
-            defaultResult.getEndTime().getName() != sect2Result.getEndTime().getName()
+            defaultResult.endTime.getName() != china95Result.endTime.getName() ||
+            defaultResult.endTime.getName() != sect1Result.endTime.getName() ||
+            defaultResult.endTime.getName() != sect2Result.endTime.getName()
         )
 
         ChildLimit.provider = DefaultChildLimitProvider()
@@ -122,8 +122,8 @@ import Testing
         for fortune in maleFortunes {
             _ = fortune.sixtyCycle
             _ = fortune.getName()
-            _ = fortune.getHeavenStem()
-            _ = fortune.getEarthBranch()
+            _ = fortune.heavenStem
+            _ = fortune.earthBranch
         }
 
         let femaleFortunes = provider.getDecadeFortunes(gender: .female, year: 2024, month: 2, day: 10, hour: 12, count: 8)
@@ -136,8 +136,8 @@ import Testing
         #expect(info.startAge == 5)
         #expect(info.endAge == 14)
         #expect(info.getName() == "甲子")
-        #expect(info.getHeavenStem().getName() == "甲")
-        #expect(info.getEarthBranch().getName() == "子")
+        #expect(info.heavenStem.getName() == "甲")
+        #expect(info.earthBranch.getName() == "子")
     }
     @Test func testThreePillars() throws {
         // Test basic creation with SixtyCycle objects
@@ -147,9 +147,9 @@ import Testing
         let threePillars = ThreePillars(year: year, month: month, day: day)
 
         #expect(threePillars.getName() == "甲戌 甲戌 甲戌")
-        #expect(threePillars.getYear().getName() == "甲戌")
-        #expect(threePillars.getMonth().getName() == "甲戌")
-        #expect(threePillars.getDay().getName() == "甲戌")
+        #expect(threePillars.year.getName() == "甲戌")
+        #expect(threePillars.month.getName() == "甲戌")
+        #expect(threePillars.day.getName() == "甲戌")
 
         // Test convenience initializer with strings
         let threePillars2 = ThreePillars(yearName: "甲戌", monthName: "甲戌", dayName: "甲戌")
@@ -161,27 +161,27 @@ import Testing
     @Test func testThreePillarsFromSolarDay() throws {
         // Aligned with tyme4j: SolarDay(1034, 10, 2) → ThreePillars = "甲戌 甲戌 甲戌"
         let solarDay = try SolarDay.fromYmd(1034, 10, 2)
-        let threePillars = solarDay.getSixtyCycleDay().getThreePillars()
+        let threePillars = solarDay.sixtyCycleDay.threePillars
         #expect(threePillars.getName() == "甲戌 甲戌 甲戌")
     }
     @Test func testThreePillarsFromMultipleDates() throws {
         // Test additional dates to verify getThreePillars consistency
         // 2024-02-10 should produce a valid ThreePillars
-        let day1 = try SolarDay.fromYmd(2024, 2, 10).getSixtyCycleDay()
-        let tp1 = day1.getThreePillars()
+        let day1 = try SolarDay.fromYmd(2024, 2, 10).sixtyCycleDay
+        let tp1 = day1.threePillars
         #expect(!tp1.getName().isEmpty)
-        #expect(tp1.getYear().getName().count == 2)
-        #expect(tp1.getMonth().getName().count == 2)
-        #expect(tp1.getDay().getName().count == 2)
+        #expect(tp1.year.getName().count == 2)
+        #expect(tp1.month.getName().count == 2)
+        #expect(tp1.day.getName().count == 2)
 
         // Verify getName format: "XX XX XX"
         let parts = tp1.getName().split(separator: " ")
         #expect(parts.count == 3)
 
         // Two consecutive days should have different day pillars but same year/month pillars (usually)
-        let day2 = try SolarDay.fromYmd(2024, 2, 11).getSixtyCycleDay()
-        let tp2 = day2.getThreePillars()
-        #expect(tp1.getDay().getName() != tp2.getDay().getName())
+        let day2 = try SolarDay.fromYmd(2024, 2, 11).sixtyCycleDay
+        let tp2 = day2.threePillars
+        #expect(tp1.day.getName() != tp2.day.getName())
     }
     @Test func testThreePillarsGetSolarDays() throws {
         // NOTE: getSolarDays crashes on certain year ranges due to a pre-existing


### PR DESCRIPTION
## Summary

- **EightChar**: expose `solarYear/Month/Day/Hour` as `public let`, update internal calls to use `yearStem.index` and `yearBranch.zodiac`; deprecate old getter methods
- **ChildLimit**: expose `gender/forward/info` as `public let`, add computed property aliases (`yearCount`, `monthCount`, `dayCount`, `hourCount`, `minuteCount`, `startTime`, `endTime`); update `init` to use new syntax; deprecate all old getters
- **ChildLimitProvider extension**: update all internal deprecated API calls (`day/hour/minute/second/year/month/dayCount`)
- **DefaultEightCharProvider**: update `solarDay`, `heavenStem.index`, `julianDay.value`
- **LunarEightCharProvider**: update `lunarDay`, `lunarMonth`, `lunarYear.year`, `heavenStem.index`, `julianDay.value`
- **DefaultDecadeFortuneProvider**: update `heavenStem.index`, `yearCount`
- **DecadeFortuneInfo**: add `heavenStem`/`earthBranch` computed properties; update internal calls; deprecate `getHeavenStem()`/`getEarthBranch()`
- All child limit providers: update `term.julianDay.solarTime`
- **EightCharTests.swift**: update all getter calls to new property syntax for eightchar + sixtycycle cross-references

## Test plan

- [x] All 114 tests pass locally
- [ ] CI passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)