### PR TITLE
feat: Culture module API modernization (getXxx → computed properties)

### DIFF
--- a/Sources/tyme/culture/Animal.swift
+++ b/Sources/tyme/culture/Animal.swift
@@ -44,9 +44,8 @@ public final class Animal: LoopTyme {
         return Animal.fromIndex(nextIndex(n))
     }
 
-    /// Get corresponding TwentyEightStar (二十八宿)
-    /// - Returns: TwentyEightStar instance
-    public func getTwentyEightStar() -> TwentyEightStar {
-        return TwentyEightStar.fromIndex(index)
-    }
+    public var twentyEightStar: TwentyEightStar { TwentyEightStar.fromIndex(index) }
+
+    @available(*, deprecated, renamed: "twentyEightStar")
+    public func getTwentyEightStar() -> TwentyEightStar { twentyEightStar }
 }

--- a/Sources/tyme/culture/Beast.swift
+++ b/Sources/tyme/culture/Beast.swift
@@ -44,9 +44,8 @@ public final class Beast: LoopTyme {
         return Beast.fromIndex(nextIndex(n))
     }
 
-    /// Get zone (宫)
-    /// - Returns: Zone instance
-    public func getZone() -> Zone {
-        return Zone.fromIndex(index)
-    }
+    public var zone: Zone { Zone.fromIndex(index) }
+
+    @available(*, deprecated, renamed: "zone")
+    public func getZone() -> Zone { zone }
 }

--- a/Sources/tyme/culture/BodyPalace.swift
+++ b/Sources/tyme/culture/BodyPalace.swift
@@ -3,7 +3,7 @@ import Foundation
 /// 身宫 (Body Palace)
 /// The body palace in BaZi astrology
 public final class BodyPalace: AbstractCulture {
-    private let sixtyCycle: SixtyCycle
+    public let sixtyCycle: SixtyCycle
 
     /// Initialize with SixtyCycle
     /// - Parameter sixtyCycle: The SixtyCycle of the body palace
@@ -18,23 +18,17 @@ public final class BodyPalace: AbstractCulture {
         return sixtyCycle.getName()
     }
 
-    /// Get SixtyCycle
-    /// - Returns: SixtyCycle instance
-    public func getSixtyCycle() -> SixtyCycle {
-        return sixtyCycle
-    }
+    public var heavenStem: HeavenStem { sixtyCycle.heavenStem }
+    public var earthBranch: EarthBranch { sixtyCycle.earthBranch }
 
-    /// Get HeavenStem
-    /// - Returns: HeavenStem instance
-    public func getHeavenStem() -> HeavenStem {
-        return sixtyCycle.getHeavenStem()
-    }
+    @available(*, deprecated, renamed: "sixtyCycle")
+    public func getSixtyCycle() -> SixtyCycle { sixtyCycle }
 
-    /// Get EarthBranch
-    /// - Returns: EarthBranch instance
-    public func getEarthBranch() -> EarthBranch {
-        return sixtyCycle.getEarthBranch()
-    }
+    @available(*, deprecated, renamed: "heavenStem")
+    public func getHeavenStem() -> HeavenStem { heavenStem }
+
+    @available(*, deprecated, renamed: "earthBranch")
+    public func getEarthBranch() -> EarthBranch { earthBranch }
 
     /// Create from year and hour
     /// - Parameters:
@@ -43,7 +37,7 @@ public final class BodyPalace: AbstractCulture {
     /// - Returns: BodyPalace instance
     public static func fromYearHour(_ yearBranch: EarthBranch, _ hourBranch: EarthBranch) -> BodyPalace {
         // Body palace calculation: year branch + hour branch - 2
-        var branchIndex = yearBranch.getIndex() + hourBranch.getIndex() - 2
+        var branchIndex = yearBranch.index + hourBranch.index - 2
         while branchIndex < 0 { branchIndex += 12 }
         branchIndex = branchIndex % 12
 

--- a/Sources/tyme/culture/Direction.swift
+++ b/Sources/tyme/culture/Direction.swift
@@ -34,8 +34,8 @@ public final class Direction: LoopTyme {
         Direction.fromIndex(nextIndex(n))
     }
     
-    // Get angle in degrees (0 = North, 90 = East, 180 = South, 270 = West)
-    public func getAngle() -> Int {
-        return index * 45  // 8 directions, 45° each
-    }
+    public var angle: Int { index * 45 }
+
+    @available(*, deprecated, renamed: "angle")
+    public func getAngle() -> Int { angle }
 }

--- a/Sources/tyme/culture/Element.swift
+++ b/Sources/tyme/culture/Element.swift
@@ -37,8 +37,8 @@ public final class Element: LoopTyme {
         Element.fromIndex(nextIndex(n))
     }
     
-    // Properties
-    public func getYinYang() -> String {
-        Element.YIN_YANG[index]
-    }
+    public var yinYang: String { Element.YIN_YANG[index] }
+
+    @available(*, deprecated, renamed: "yinYang")
+    public func getYinYang() -> String { yinYang }
 }

--- a/Sources/tyme/culture/KitchenGodSteed.swift
+++ b/Sources/tyme/culture/KitchenGodSteed.swift
@@ -9,7 +9,7 @@ public final class KitchenGodSteed: AbstractCulture {
     private let firstDaySixtyCycle: SixtyCycle
 
     public init(lunarYear: Int) {
-        firstDaySixtyCycle = try! LunarDay.fromYmd(lunarYear, 1, 1).getSixtyCycle()
+        firstDaySixtyCycle = try! LunarDay.fromYmd(lunarYear, 1, 1).sixtyCycle
     }
 
     public static func fromLunarYear(_ lunarYear: Int) -> KitchenGodSteed {
@@ -17,82 +17,42 @@ public final class KitchenGodSteed: AbstractCulture {
     }
 
     private func byHeavenStem(_ n: Int) -> String {
-        KitchenGodSteed.NUMBERS[firstDaySixtyCycle.getHeavenStem().stepsTo(n)]
+        KitchenGodSteed.NUMBERS[firstDaySixtyCycle.heavenStem.stepsTo(n)]
     }
 
     private func byEarthBranch(_ n: Int) -> String {
-        KitchenGodSteed.NUMBERS[firstDaySixtyCycle.getEarthBranch().stepsTo(n)]
+        KitchenGodSteed.NUMBERS[firstDaySixtyCycle.earthBranch.stepsTo(n)]
     }
 
-    /// 几鼠偷粮
-    public func getMouse() -> String {
-        "\(byEarthBranch(0))鼠偷粮"
-    }
+    public var mouse: String { "\(byEarthBranch(0))鼠偷粮" }
+    public var grass: String { "草子\(byEarthBranch(0))分" }
+    public var cattle: String { "\(byEarthBranch(1))牛耕田" }
+    public var flower: String { "花收\(byEarthBranch(3))分" }
+    public var dragon: String { "\(byEarthBranch(4))龙治水" }
+    public var horse: String { "\(byEarthBranch(6))马驮谷" }
+    public var chicken: String { "\(byEarthBranch(9))鸡抢米" }
+    public var silkworm: String { "\(byEarthBranch(9))姑看蚕" }
+    public var pig: String { "\(byEarthBranch(11))屠共猪" }
+    public var field: String { "甲田\(byHeavenStem(0))分" }
+    public var cake: String { "\(byHeavenStem(2))人分饼" }
+    public var gold: String { "\(byHeavenStem(7))日得金" }
+    public var peopleCakes: String { "\(byEarthBranch(2))人\(byHeavenStem(2))丙" }
+    public var peopleHoes: String { "\(byEarthBranch(2))人\(byHeavenStem(3))锄" }
 
-    /// 草子几分
-    public func getGrass() -> String {
-        "草子\(byEarthBranch(0))分"
-    }
-
-    /// 几牛耕田
-    public func getCattle() -> String {
-        "\(byEarthBranch(1))牛耕田"
-    }
-
-    /// 花收几分
-    public func getFlower() -> String {
-        "花收\(byEarthBranch(3))分"
-    }
-
-    /// 几龙治水
-    public func getDragon() -> String {
-        "\(byEarthBranch(4))龙治水"
-    }
-
-    /// 几马驮谷
-    public func getHorse() -> String {
-        "\(byEarthBranch(6))马驮谷"
-    }
-
-    /// 几鸡抢米
-    public func getChicken() -> String {
-        "\(byEarthBranch(9))鸡抢米"
-    }
-
-    /// 几姑看蚕
-    public func getSilkworm() -> String {
-        "\(byEarthBranch(9))姑看蚕"
-    }
-
-    /// 几屠共猪
-    public func getPig() -> String {
-        "\(byEarthBranch(11))屠共猪"
-    }
-
-    /// 甲田几分
-    public func getField() -> String {
-        "甲田\(byHeavenStem(0))分"
-    }
-
-    /// 几人分饼
-    public func getCake() -> String {
-        "\(byHeavenStem(2))人分饼"
-    }
-
-    /// 几日得金
-    public func getGold() -> String {
-        "\(byHeavenStem(7))日得金"
-    }
-
-    /// 几人几丙
-    public func getPeopleCakes() -> String {
-        "\(byEarthBranch(2))人\(byHeavenStem(2))丙"
-    }
-
-    /// 几人几锄
-    public func getPeopleHoes() -> String {
-        "\(byEarthBranch(2))人\(byHeavenStem(3))锄"
-    }
+    @available(*, deprecated, renamed: "mouse") public func getMouse() -> String { mouse }
+    @available(*, deprecated, renamed: "grass") public func getGrass() -> String { grass }
+    @available(*, deprecated, renamed: "cattle") public func getCattle() -> String { cattle }
+    @available(*, deprecated, renamed: "flower") public func getFlower() -> String { flower }
+    @available(*, deprecated, renamed: "dragon") public func getDragon() -> String { dragon }
+    @available(*, deprecated, renamed: "horse") public func getHorse() -> String { horse }
+    @available(*, deprecated, renamed: "chicken") public func getChicken() -> String { chicken }
+    @available(*, deprecated, renamed: "silkworm") public func getSilkworm() -> String { silkworm }
+    @available(*, deprecated, renamed: "pig") public func getPig() -> String { pig }
+    @available(*, deprecated, renamed: "field") public func getField() -> String { field }
+    @available(*, deprecated, renamed: "cake") public func getCake() -> String { cake }
+    @available(*, deprecated, renamed: "gold") public func getGold() -> String { gold }
+    @available(*, deprecated, renamed: "peopleCakes") public func getPeopleCakes() -> String { peopleCakes }
+    @available(*, deprecated, renamed: "peopleHoes") public func getPeopleHoes() -> String { peopleHoes }
 
     public override func getName() -> String {
         "灶马头"

--- a/Sources/tyme/culture/Land.swift
+++ b/Sources/tyme/culture/Land.swift
@@ -45,9 +45,8 @@ public final class Land: LoopTyme {
         return Land.fromIndex(nextIndex(n))
     }
 
-    /// Get direction (方位)
-    /// - Returns: Direction instance
-    public func getDirection() -> Direction {
-        return Direction.fromIndex(index)
-    }
+    public var direction: Direction { Direction.fromIndex(index) }
+
+    @available(*, deprecated, renamed: "direction")
+    public func getDirection() -> Direction { direction }
 }

--- a/Sources/tyme/culture/LifePalace.swift
+++ b/Sources/tyme/culture/LifePalace.swift
@@ -3,7 +3,7 @@ import Foundation
 /// 命宫 (Life Palace)
 /// The life palace in BaZi astrology
 public final class LifePalace: AbstractCulture {
-    private let sixtyCycle: SixtyCycle
+    public let sixtyCycle: SixtyCycle
 
     /// Initialize with SixtyCycle
     /// - Parameter sixtyCycle: The SixtyCycle of the life palace
@@ -18,23 +18,17 @@ public final class LifePalace: AbstractCulture {
         return sixtyCycle.getName()
     }
 
-    /// Get SixtyCycle
-    /// - Returns: SixtyCycle instance
-    public func getSixtyCycle() -> SixtyCycle {
-        return sixtyCycle
-    }
+    public var heavenStem: HeavenStem { sixtyCycle.heavenStem }
+    public var earthBranch: EarthBranch { sixtyCycle.earthBranch }
 
-    /// Get HeavenStem
-    /// - Returns: HeavenStem instance
-    public func getHeavenStem() -> HeavenStem {
-        return sixtyCycle.getHeavenStem()
-    }
+    @available(*, deprecated, renamed: "sixtyCycle")
+    public func getSixtyCycle() -> SixtyCycle { sixtyCycle }
 
-    /// Get EarthBranch
-    /// - Returns: EarthBranch instance
-    public func getEarthBranch() -> EarthBranch {
-        return sixtyCycle.getEarthBranch()
-    }
+    @available(*, deprecated, renamed: "heavenStem")
+    public func getHeavenStem() -> HeavenStem { heavenStem }
+
+    @available(*, deprecated, renamed: "earthBranch")
+    public func getEarthBranch() -> EarthBranch { earthBranch }
 
     /// Create from year and month
     /// - Parameters:
@@ -43,7 +37,7 @@ public final class LifePalace: AbstractCulture {
     /// - Returns: LifePalace instance
     public static func fromYearMonth(_ yearBranch: EarthBranch, _ monthBranch: EarthBranch) -> LifePalace {
         // Life palace calculation: 14 - year branch - month branch
-        var branchIndex = 14 - yearBranch.getIndex() - monthBranch.getIndex()
+        var branchIndex = 14 - yearBranch.index - monthBranch.index
         while branchIndex < 0 { branchIndex += 12 }
         branchIndex = branchIndex % 12
 

--- a/Sources/tyme/culture/Luck.swift
+++ b/Sources/tyme/culture/Luck.swift
@@ -44,15 +44,12 @@ public final class Luck: LoopTyme {
         return Luck.fromIndex(nextIndex(n))
     }
 
-    /// Check if auspicious
-    /// - Returns: true if 吉
-    public func isAuspicious() -> Bool {
-        return index == 0
-    }
+    public var auspicious: Bool { index == 0 }
+    public var inauspicious: Bool { index == 1 }
 
-    /// Check if inauspicious
-    /// - Returns: true if 凶
-    public func isInauspicious() -> Bool {
-        return index == 1
-    }
+    @available(*, deprecated, renamed: "auspicious")
+    public func isAuspicious() -> Bool { auspicious }
+
+    @available(*, deprecated, renamed: "inauspicious")
+    public func isInauspicious() -> Bool { inauspicious }
 }

--- a/Sources/tyme/culture/NaYin.swift
+++ b/Sources/tyme/culture/NaYin.swift
@@ -68,15 +68,12 @@ public final class NaYin: LoopTyme {
         return NaYin.fromIndex(nextIndex(n))
     }
 
-    /// Get WuXing (五行)
-    /// - Returns: Element name (金, 木, 水, 火, 土)
-    public func getWuXing() -> String {
-        return NaYin.WU_XING[index]
-    }
+    public var wuXing: String { NaYin.WU_XING[index] }
+    public var element: Element { try! Element.fromName(NaYin.WU_XING[index]) }
 
-    /// Get Element instance
-    /// - Returns: Element instance
-    public func getElement() -> Element {
-        return try! Element.fromName(NaYin.WU_XING[index])
-    }
+    @available(*, deprecated, renamed: "wuXing")
+    public func getWuXing() -> String { wuXing }
+
+    @available(*, deprecated, renamed: "element")
+    public func getElement() -> Element { element }
 }

--- a/Sources/tyme/culture/PhaseDay.swift
+++ b/Sources/tyme/culture/PhaseDay.swift
@@ -45,9 +45,8 @@ public final class PhaseDay: LoopTyme {
         return PhaseDay.fromIndex(nextIndex(n))
     }
 
-    /// Get day number (1-5)
-    /// - Returns: Day number
-    public func getDayNumber() -> Int {
-        return index + 1
-    }
+    public var dayNumber: Int { index + 1 }
+
+    @available(*, deprecated, renamed: "dayNumber")
+    public func getDayNumber() -> Int { dayNumber }
 }

--- a/Sources/tyme/culture/Phenology.swift
+++ b/Sources/tyme/culture/Phenology.swift
@@ -70,15 +70,12 @@ public final class Phenology: LoopTyme {
         return Phenology.fromIndex(nextIndex(n))
     }
 
-    /// Get the three-phenology period (三候)
-    /// - Returns: ThreePhenology instance (初候, 二候, 三候)
-    public func getThreePhenology() -> ThreePhenology {
-        return ThreePhenology.fromIndex(index % 3)
-    }
+    public var threePhenology: ThreePhenology { ThreePhenology.fromIndex(index % 3) }
+    public var solarTermIndex: Int { index / 3 }
 
-    /// Get the solar term index this phenology belongs to
-    /// - Returns: Solar term index (0-23)
-    public func getSolarTermIndex() -> Int {
-        return index / 3
-    }
+    @available(*, deprecated, renamed: "threePhenology")
+    public func getThreePhenology() -> ThreePhenology { threePhenology }
+
+    @available(*, deprecated, renamed: "solarTermIndex")
+    public func getSolarTermIndex() -> Int { solarTermIndex }
 }

--- a/Sources/tyme/culture/PhenologyDay.swift
+++ b/Sources/tyme/culture/PhenologyDay.swift
@@ -11,9 +11,8 @@ public final class PhenologyDay: AbstractCultureDay {
         super.init(culture: phenology, dayIndex: dayIndex)
     }
 
-    /// Get phenology
-    /// - Returns: Phenology instance
-    public func getPhenology() -> Phenology {
-        return culture as! Phenology
-    }
+    public var phenology: Phenology { culture as! Phenology }
+
+    @available(*, deprecated, renamed: "phenology")
+    public func getPhenology() -> Phenology { phenology }
 }

--- a/Sources/tyme/culture/Sixty.swift
+++ b/Sources/tyme/culture/Sixty.swift
@@ -44,27 +44,20 @@ public final class Sixty: LoopTyme {
         return Sixty.fromIndex(nextIndex(n))
     }
 
-    /// Get SixtyCycle
-    /// - Returns: SixtyCycle instance
-    public func getSixtyCycle() -> SixtyCycle {
-        return SixtyCycle.fromIndex(index)
-    }
+    public var sixtyCycle: SixtyCycle { SixtyCycle.fromIndex(index) }
+    public var naYin: NaYin { NaYin.fromSixtyCycle(index) }
+    public var heavenStem: HeavenStem { HeavenStem.fromIndex(index % 10) }
+    public var earthBranch: EarthBranch { EarthBranch.fromIndex(index % 12) }
 
-    /// Get NaYin
-    /// - Returns: NaYin instance
-    public func getNaYin() -> NaYin {
-        return NaYin.fromSixtyCycle(index)
-    }
+    @available(*, deprecated, renamed: "sixtyCycle")
+    public func getSixtyCycle() -> SixtyCycle { sixtyCycle }
 
-    /// Get HeavenStem
-    /// - Returns: HeavenStem instance
-    public func getHeavenStem() -> HeavenStem {
-        return HeavenStem.fromIndex(index % 10)
-    }
+    @available(*, deprecated, renamed: "naYin")
+    public func getNaYin() -> NaYin { naYin }
 
-    /// Get EarthBranch
-    /// - Returns: EarthBranch instance
-    public func getEarthBranch() -> EarthBranch {
-        return EarthBranch.fromIndex(index % 12)
-    }
+    @available(*, deprecated, renamed: "heavenStem")
+    public func getHeavenStem() -> HeavenStem { heavenStem }
+
+    @available(*, deprecated, renamed: "earthBranch")
+    public func getEarthBranch() -> EarthBranch { earthBranch }
 }

--- a/Sources/tyme/culture/Sound.swift
+++ b/Sources/tyme/culture/Sound.swift
@@ -49,15 +49,12 @@ public final class Sound: LoopTyme {
         return Sound.fromIndex(nextIndex(n))
     }
 
-    /// Get WuXing (五行)
-    /// - Returns: Element name (金, 木, 水, 火, 土)
-    public func getWuXing() -> String {
-        return Sound.WU_XING[index]
-    }
+    public var wuXing: String { Sound.WU_XING[index] }
+    public var element: Element { try! Element.fromName(Sound.WU_XING[index]) }
 
-    /// Get Element instance
-    /// - Returns: Element instance
-    public func getElement() -> Element {
-        return try! Element.fromName(Sound.WU_XING[index])
-    }
+    @available(*, deprecated, renamed: "wuXing")
+    public func getWuXing() -> String { wuXing }
+
+    @available(*, deprecated, renamed: "element")
+    public func getElement() -> Element { element }
 }

--- a/Sources/tyme/culture/Ten.swift
+++ b/Sources/tyme/culture/Ten.swift
@@ -44,9 +44,8 @@ public final class Ten: LoopTyme {
         return Ten.fromIndex(nextIndex(n))
     }
 
-    /// Get day number (1-10)
-    /// - Returns: Day number
-    public func getDayNumber() -> Int {
-        return index + 1
-    }
+    public var dayNumber: Int { index + 1 }
+
+    @available(*, deprecated, renamed: "dayNumber")
+    public func getDayNumber() -> Int { dayNumber }
 }

--- a/Sources/tyme/culture/TenDay.swift
+++ b/Sources/tyme/culture/TenDay.swift
@@ -45,9 +45,8 @@ public final class TenDay: LoopTyme {
         return TenDay.fromIndex(nextIndex(n))
     }
 
-    /// Get corresponding HeavenStem
-    /// - Returns: HeavenStem instance
-    public func getHeavenStem() -> HeavenStem {
-        return HeavenStem.fromIndex(index)
-    }
+    public var heavenStem: HeavenStem { HeavenStem.fromIndex(index) }
+
+    @available(*, deprecated, renamed: "heavenStem")
+    public func getHeavenStem() -> HeavenStem { heavenStem }
 }

--- a/Sources/tyme/culture/Terrain.swift
+++ b/Sources/tyme/culture/Terrain.swift
@@ -45,21 +45,16 @@ public final class Terrain: LoopTyme {
         return Terrain.fromIndex(nextIndex(n))
     }
 
-    /// Check if this is a prosperous stage (旺相)
-    /// - Returns: true if 长生, 冠带, 临官, 帝旺
-    public func isProsperous() -> Bool {
-        return index == 0 || index == 2 || index == 3 || index == 4
-    }
+    public var prosperous: Bool { index == 0 || index == 2 || index == 3 || index == 4 }
+    public var declining: Bool { index >= 5 && index <= 9 }
+    public var nurturing: Bool { index == 1 || index == 10 || index == 11 }
 
-    /// Check if this is a declining stage (衰败)
-    /// - Returns: true if 衰, 病, 死, 墓, 绝
-    public func isDeclining() -> Bool {
-        return index >= 5 && index <= 9
-    }
+    @available(*, deprecated, renamed: "prosperous")
+    public func isProsperous() -> Bool { prosperous }
 
-    /// Check if this is a nurturing stage (养育)
-    /// - Returns: true if 胎, 养, 沐浴
-    public func isNurturing() -> Bool {
-        return index == 1 || index == 10 || index == 11
-    }
+    @available(*, deprecated, renamed: "declining")
+    public func isDeclining() -> Bool { declining }
+
+    @available(*, deprecated, renamed: "nurturing")
+    public func isNurturing() -> Bool { nurturing }
 }

--- a/Sources/tyme/culture/Twenty.swift
+++ b/Sources/tyme/culture/Twenty.swift
@@ -49,9 +49,8 @@ public final class Twenty: LoopTyme {
         return Twenty.fromIndex(nextIndex(n))
     }
 
-    /// Get day number (1-20)
-    /// - Returns: Day number
-    public func getDayNumber() -> Int {
-        return index + 1
-    }
+    public var dayNumber: Int { index + 1 }
+
+    @available(*, deprecated, renamed: "dayNumber")
+    public func getDayNumber() -> Int { dayNumber }
 }

--- a/Sources/tyme/culture/Zodiac.swift
+++ b/Sources/tyme/culture/Zodiac.swift
@@ -46,9 +46,8 @@ public final class Zodiac: LoopTyme {
         return Zodiac.fromIndex(nextIndex(n))
     }
 
-    /// Get corresponding earth branch
-    /// - Returns: EarthBranch corresponding to this zodiac
-    public func getEarthBranch() -> EarthBranch {
-        return EarthBranch.fromIndex(index)
-    }
+    public var earthBranch: EarthBranch { EarthBranch.fromIndex(index) }
+
+    @available(*, deprecated, renamed: "earthBranch")
+    public func getEarthBranch() -> EarthBranch { earthBranch }
 }

--- a/Sources/tyme/culture/Zone.swift
+++ b/Sources/tyme/culture/Zone.swift
@@ -44,15 +44,12 @@ public final class Zone: LoopTyme {
         return Zone.fromIndex(nextIndex(n))
     }
 
-    /// Get direction
-    /// - Returns: Direction instance
-    public func getDirection() -> Direction {
-        return try! Direction.fromName(getName())
-    }
+    public var direction: Direction { try! Direction.fromName(getName()) }
+    public var beast: Beast { Beast.fromIndex(index) }
 
-    /// Get beast (神兽)
-    /// - Returns: Beast instance
-    public func getBeast() -> Beast {
-        return Beast.fromIndex(index)
-    }
+    @available(*, deprecated, renamed: "direction")
+    public func getDirection() -> Direction { direction }
+
+    @available(*, deprecated, renamed: "beast")
+    public func getBeast() -> Beast { beast }
 }

--- a/Sources/tyme/culture/dog/DogDay.swift
+++ b/Sources/tyme/culture/dog/DogDay.swift
@@ -11,16 +11,15 @@ public final class DogDay: AbstractCultureDay {
         super.init(culture: dog, dayIndex: dayIndex)
     }
 
-    /// Get dog period
-    /// - Returns: Dog instance
-    public func getDog() -> Dog {
-        return culture as! Dog
-    }
+    public var dog: Dog { culture as! Dog }
+
+    @available(*, deprecated, renamed: "dog")
+    public func getDog() -> Dog { dog }
 
     /// Get name
     /// - Returns: Dog day name (e.g., "初伏第1天")
     public override func getName() -> String {
-        return "\(getDog().getName())第\(getDayIndex() + 1)天"
+        return "\(dog.getName())第\(dayIndex + 1)天"
     }
 
     /// Create from dog period and day index

--- a/Sources/tyme/culture/fetus/Fetus.swift
+++ b/Sources/tyme/culture/fetus/Fetus.swift
@@ -36,7 +36,7 @@ public final class Fetus: AbstractCulture {
         "房内西", "房内北", "房内北", "房内北", "房内北"
     ]
 
-    private let sixtyCycleIndex: Int
+    public let sixtyCycleIndex: Int
 
     /// Initialize with SixtyCycle index
     /// - Parameter sixtyCycleIndex: SixtyCycle index (0-59)
@@ -47,35 +47,29 @@ public final class Fetus: AbstractCulture {
         super.init()
     }
 
+    public var position: String { Fetus.POSITIONS[sixtyCycleIndex] }
+    public var direction: String { Fetus.DIRECTIONS[sixtyCycleIndex] }
+
     /// Get name (position + direction)
     /// - Returns: Fetus god name
     public override func getName() -> String {
-        return "\(getPosition())\(getDirection())"
+        return "\(position)\(direction)"
     }
 
-    /// Get position
-    /// - Returns: Position name
-    public func getPosition() -> String {
-        return Fetus.POSITIONS[sixtyCycleIndex]
-    }
+    @available(*, deprecated, renamed: "position")
+    public func getPosition() -> String { position }
 
-    /// Get direction
-    /// - Returns: Direction name
-    public func getDirection() -> String {
-        return Fetus.DIRECTIONS[sixtyCycleIndex]
-    }
+    @available(*, deprecated, renamed: "direction")
+    public func getDirection() -> String { direction }
 
-    /// Get SixtyCycle index
-    /// - Returns: SixtyCycle index
-    public func getSixtyCycleIndex() -> Int {
-        return sixtyCycleIndex
-    }
+    @available(*, deprecated, renamed: "sixtyCycleIndex")
+    public func getSixtyCycleIndex() -> Int { sixtyCycleIndex }
 
     /// Create from SixtyCycle
     /// - Parameter sixtyCycle: SixtyCycle instance
     /// - Returns: Fetus instance
     public static func fromSixtyCycle(_ sixtyCycle: SixtyCycle) -> Fetus {
-        return Fetus(sixtyCycleIndex: sixtyCycle.getIndex())
+        return Fetus(sixtyCycleIndex: sixtyCycle.index)
     }
 
     /// Create from SixtyCycle index

--- a/Sources/tyme/culture/fetus/FetusDay.swift
+++ b/Sources/tyme/culture/fetus/FetusDay.swift
@@ -16,15 +16,15 @@ public final class FetusDay: AbstractCulture {
         7, 2, 2, 2, 2, 2, 3, 3, 3, 3
     ]
 
-    private let fetusHeavenStem: FetusHeavenStem
-    private let fetusEarthBranch: FetusEarthBranch
-    private let side: Side
-    private let directionName: String
+    public let fetusHeavenStem: FetusHeavenStem
+    public let fetusEarthBranch: FetusEarthBranch
+    public let side: Side
+    public let directionName: String
 
     public init(sixtyCycle: SixtyCycle) {
-        self.fetusHeavenStem = FetusHeavenStem(index: sixtyCycle.getHeavenStem().getIndex() % 5)
-        self.fetusEarthBranch = FetusEarthBranch(index: sixtyCycle.getEarthBranch().getIndex() % 6)
-        let idx = FetusDay.SIDE_DIRECTION_INDEX[sixtyCycle.getIndex()]
+        self.fetusHeavenStem = FetusHeavenStem(index: sixtyCycle.heavenStem.index % 5)
+        self.fetusEarthBranch = FetusEarthBranch(index: sixtyCycle.earthBranch.index % 6)
+        let idx = FetusDay.SIDE_DIRECTION_INDEX[sixtyCycle.index]
         self.side = Side.fromIndex(idx < 0 ? 0 : 1)
         let c = FetusDay.DIRECTION_NAMES.count
         var di = idx % c
@@ -36,15 +36,15 @@ public final class FetusDay: AbstractCulture {
     public static func fromLunarDay(_ lunarDay: LunarDay) -> FetusDay {
         // Compute SixtyCycle directly from JulianDay to work around
         // LunarDay.getSolarDay() off-by-one in the Swift port
-        let jd = lunarDay.getLunarMonth().getFirstJulianDay().next(lunarDay.getDay())
-        let offset = Int(jd.getDay() + 0.5) + 49
+        let jd = lunarDay.lunarMonth.firstJulianDay.next(lunarDay.day)
+        let offset = Int(jd.value + 0.5) + 49
         var index = offset % 60
         if index < 0 { index += 60 }
         return FetusDay(sixtyCycle: SixtyCycle.fromIndex(index))
     }
 
     public static func fromSixtyCycleDay(_ sixtyCycleDay: SixtyCycleDay) -> FetusDay {
-        FetusDay(sixtyCycle: sixtyCycleDay.getSixtyCycle())
+        FetusDay(sixtyCycle: sixtyCycleDay.sixtyCycle)
     }
 
     public override func getName() -> String {
@@ -73,19 +73,15 @@ public final class FetusDay: AbstractCulture {
         return s
     }
 
-    public func getSide() -> Side {
-        side
-    }
+    @available(*, deprecated, renamed: "side")
+    public func getSide() -> Side { side }
 
-    public func getDirectionName() -> String {
-        directionName
-    }
+    @available(*, deprecated, renamed: "directionName")
+    public func getDirectionName() -> String { directionName }
 
-    public func getFetusHeavenStem() -> FetusHeavenStem {
-        fetusHeavenStem
-    }
+    @available(*, deprecated, renamed: "fetusHeavenStem")
+    public func getFetusHeavenStem() -> FetusHeavenStem { fetusHeavenStem }
 
-    public func getFetusEarthBranch() -> FetusEarthBranch {
-        fetusEarthBranch
-    }
+    @available(*, deprecated, renamed: "fetusEarthBranch")
+    public func getFetusEarthBranch() -> FetusEarthBranch { fetusEarthBranch }
 }

--- a/Sources/tyme/culture/fetus/FetusOrigin.swift
+++ b/Sources/tyme/culture/fetus/FetusOrigin.swift
@@ -3,7 +3,7 @@ import Foundation
 /// 胎元 (Fetus Origin)
 /// The conception month pillar in BaZi
 public final class FetusOrigin: AbstractCulture {
-    private let sixtyCycle: SixtyCycle
+    public let sixtyCycle: SixtyCycle
 
     /// Initialize with SixtyCycle
     /// - Parameter sixtyCycle: The SixtyCycle of the fetus origin
@@ -18,23 +18,17 @@ public final class FetusOrigin: AbstractCulture {
         return sixtyCycle.getName()
     }
 
-    /// Get SixtyCycle
-    /// - Returns: SixtyCycle instance
-    public func getSixtyCycle() -> SixtyCycle {
-        return sixtyCycle
-    }
+    public var heavenStem: HeavenStem { sixtyCycle.heavenStem }
+    public var earthBranch: EarthBranch { sixtyCycle.earthBranch }
 
-    /// Get HeavenStem
-    /// - Returns: HeavenStem instance
-    public func getHeavenStem() -> HeavenStem {
-        return sixtyCycle.getHeavenStem()
-    }
+    @available(*, deprecated, renamed: "sixtyCycle")
+    public func getSixtyCycle() -> SixtyCycle { sixtyCycle }
 
-    /// Get EarthBranch
-    /// - Returns: EarthBranch instance
-    public func getEarthBranch() -> EarthBranch {
-        return sixtyCycle.getEarthBranch()
-    }
+    @available(*, deprecated, renamed: "heavenStem")
+    public func getHeavenStem() -> HeavenStem { heavenStem }
+
+    @available(*, deprecated, renamed: "earthBranch")
+    public func getEarthBranch() -> EarthBranch { earthBranch }
 
     /// Create from month pillar
     /// The fetus origin is calculated as month pillar + 1 stem + 3 branches
@@ -42,8 +36,8 @@ public final class FetusOrigin: AbstractCulture {
     /// - Returns: FetusOrigin instance
     public static func fromMonthPillar(_ monthPillar: SixtyCycle) -> FetusOrigin {
         // Fetus origin = month stem + 1, month branch + 3
-        let stemIndex = (monthPillar.getHeavenStem().getIndex() + 1) % 10
-        let branchIndex = (monthPillar.getEarthBranch().getIndex() + 3) % 12
+        let stemIndex = (monthPillar.heavenStem.index + 1) % 10
+        let branchIndex = (monthPillar.earthBranch.index + 3) % 12
 
         // Calculate SixtyCycle index
         var index = stemIndex

--- a/Sources/tyme/culture/god/DayGod.swift
+++ b/Sources/tyme/culture/god/DayGod.swift
@@ -53,23 +53,18 @@ public final class DayGod: AbstractCulture {
         return dayGodName
     }
 
-    /// Check if auspicious
-    /// - Returns: true if auspicious
-    public func getIsAuspicious() -> Bool {
-        return isAuspicious
-    }
+    public var auspicious: Bool { isAuspicious }
+    public var inauspicious: Bool { !isAuspicious }
+    public var luck: Luck { Luck.fromIndex(isAuspicious ? 0 : 1) }
 
-    /// Check if inauspicious
-    /// - Returns: true if inauspicious
-    public func getIsInauspicious() -> Bool {
-        return !isAuspicious
-    }
+    @available(*, deprecated, renamed: "auspicious")
+    public func getIsAuspicious() -> Bool { auspicious }
 
-    /// Get luck
-    /// - Returns: Luck instance
-    public func getLuck() -> Luck {
-        return Luck.fromIndex(isAuspicious ? 0 : 1)
-    }
+    @available(*, deprecated, renamed: "inauspicious")
+    public func getIsInauspicious() -> Bool { inauspicious }
+
+    @available(*, deprecated, renamed: "luck")
+    public func getLuck() -> Luck { luck }
 
     /// Create auspicious day god
     /// - Parameter name: Day god name

--- a/Sources/tyme/culture/god/FortuneGod.swift
+++ b/Sources/tyme/culture/god/FortuneGod.swift
@@ -23,23 +23,22 @@ public final class FortuneGod: AbstractCulture {
         return FortuneGod.DIRECTIONS[heavenStemIndex]
     }
 
-    /// Get direction
-    /// - Returns: Direction instance
-    public func getDirection() -> Direction {
-        return try! Direction.fromName(getName())
-    }
+    public var direction: Direction { try! Direction.fromName(getName()) }
+
+    @available(*, deprecated, renamed: "direction")
+    public func getDirection() -> Direction { direction }
 
     /// Create from heaven stem
     /// - Parameter heavenStem: Heaven stem
     /// - Returns: FortuneGod instance
     public static func fromHeavenStem(_ heavenStem: HeavenStem) -> FortuneGod {
-        return FortuneGod(heavenStemIndex: heavenStem.getIndex())
+        return FortuneGod(heavenStemIndex: heavenStem.index)
     }
 
     /// Create from day SixtyCycle
     /// - Parameter daySixtyCycle: Day SixtyCycle
     /// - Returns: FortuneGod instance
     public static func fromDaySixtyCycle(_ daySixtyCycle: SixtyCycle) -> FortuneGod {
-        return FortuneGod(heavenStemIndex: daySixtyCycle.getHeavenStem().getIndex())
+        return FortuneGod(heavenStemIndex: daySixtyCycle.heavenStem.index)
     }
 }

--- a/Sources/tyme/culture/god/God.swift
+++ b/Sources/tyme/culture/god/God.swift
@@ -4,8 +4,8 @@ import Foundation
 /// Represents various deities and spirits in Chinese calendar
 /// Used for determining auspicious and inauspicious activities
 public final class God: AbstractCulture {
-    private let godType: GodType
-    private let luck: Luck
+    public let godType: GodType
+    public let luck: Luck
     private let godName: String
 
     /// Initialize with type, luck, and name
@@ -26,27 +26,18 @@ public final class God: AbstractCulture {
         return godName
     }
 
-    /// Get god type
-    /// - Returns: GodType instance
-    public func getGodType() -> GodType {
-        return godType
-    }
+    public var auspicious: Bool { luck.auspicious }
+    public var inauspicious: Bool { luck.inauspicious }
 
-    /// Get luck
-    /// - Returns: Luck instance
-    public func getLuck() -> Luck {
-        return luck
-    }
+    @available(*, deprecated, renamed: "godType")
+    public func getGodType() -> GodType { godType }
 
-    /// Check if auspicious
-    /// - Returns: true if 吉
-    public func isAuspicious() -> Bool {
-        return luck.isAuspicious()
-    }
+    @available(*, deprecated, renamed: "luck")
+    public func getLuck() -> Luck { luck }
 
-    /// Check if inauspicious
-    /// - Returns: true if 凶
-    public func isInauspicious() -> Bool {
-        return luck.isInauspicious()
-    }
+    @available(*, deprecated, renamed: "auspicious")
+    public func isAuspicious() -> Bool { auspicious }
+
+    @available(*, deprecated, renamed: "inauspicious")
+    public func isInauspicious() -> Bool { inauspicious }
 }

--- a/Sources/tyme/culture/god/HourGod.swift
+++ b/Sources/tyme/culture/god/HourGod.swift
@@ -9,28 +9,25 @@ public final class HourGod: AbstractCulture {
         "天乙", "天官", "福星", "天德", "月德"
     ]
 
-    private let hourGodIndex: Int
+    public let index: Int
 
     /// Initialize with index
     /// - Parameter index: Hour god index (0-9)
     public init(index: Int) {
         var i = index % 10
         if i < 0 { i += 10 }
-        self.hourGodIndex = i
+        self.index = i
         super.init()
     }
 
     /// Get name
     /// - Returns: Hour god name
     public override func getName() -> String {
-        return HourGod.NAMES[hourGodIndex]
+        return HourGod.NAMES[index]
     }
 
-    /// Get index
-    /// - Returns: Hour god index
-    public func getIndex() -> Int {
-        return hourGodIndex
-    }
+    @available(*, deprecated, renamed: "index")
+    public func getIndex() -> Int { index }
 
     /// Create from index
     /// - Parameter index: Hour god index

--- a/Sources/tyme/culture/god/JoyGod.swift
+++ b/Sources/tyme/culture/god/JoyGod.swift
@@ -24,23 +24,22 @@ public final class JoyGod: AbstractCulture {
         return JoyGod.DIRECTIONS[heavenStemIndex % 5]
     }
 
-    /// Get direction
-    /// - Returns: Direction instance
-    public func getDirection() -> Direction {
-        return try! Direction.fromName(getName())
-    }
+    public var direction: Direction { try! Direction.fromName(getName()) }
+
+    @available(*, deprecated, renamed: "direction")
+    public func getDirection() -> Direction { direction }
 
     /// Create from heaven stem
     /// - Parameter heavenStem: Heaven stem
     /// - Returns: JoyGod instance
     public static func fromHeavenStem(_ heavenStem: HeavenStem) -> JoyGod {
-        return JoyGod(heavenStemIndex: heavenStem.getIndex())
+        return JoyGod(heavenStemIndex: heavenStem.index)
     }
 
     /// Create from day SixtyCycle
     /// - Parameter daySixtyCycle: Day SixtyCycle
     /// - Returns: JoyGod instance
     public static func fromDaySixtyCycle(_ daySixtyCycle: SixtyCycle) -> JoyGod {
-        return JoyGod(heavenStemIndex: daySixtyCycle.getHeavenStem().getIndex())
+        return JoyGod(heavenStemIndex: daySixtyCycle.heavenStem.index)
     }
 }

--- a/Sources/tyme/culture/god/MonthGod.swift
+++ b/Sources/tyme/culture/god/MonthGod.swift
@@ -9,28 +9,25 @@ public final class MonthGod: AbstractCulture {
         "月厌", "大耗", "小耗", "月建", "月破"
     ]
 
-    private let monthGodIndex: Int
+    public let index: Int
 
     /// Initialize with index
     /// - Parameter index: Month god index (0-9)
     public init(index: Int) {
         var i = index % 10
         if i < 0 { i += 10 }
-        self.monthGodIndex = i
+        self.index = i
         super.init()
     }
 
     /// Get name
     /// - Returns: Month god name
     public override func getName() -> String {
-        return MonthGod.NAMES[monthGodIndex]
+        return MonthGod.NAMES[index]
     }
 
-    /// Get index
-    /// - Returns: Month god index
-    public func getIndex() -> Int {
-        return monthGodIndex
-    }
+    @available(*, deprecated, renamed: "index")
+    public func getIndex() -> Int { index }
 
     /// Create from index
     /// - Parameter index: Month god index

--- a/Sources/tyme/culture/god/WealthGod.swift
+++ b/Sources/tyme/culture/god/WealthGod.swift
@@ -24,23 +24,22 @@ public final class WealthGod: AbstractCulture {
         return WealthGod.DIRECTIONS[heavenStemIndex]
     }
 
-    /// Get direction
-    /// - Returns: Direction instance
-    public func getDirection() -> Direction {
-        return try! Direction.fromName(getName())
-    }
+    public var direction: Direction { try! Direction.fromName(getName()) }
+
+    @available(*, deprecated, renamed: "direction")
+    public func getDirection() -> Direction { direction }
 
     /// Create from heaven stem
     /// - Parameter heavenStem: Heaven stem
     /// - Returns: WealthGod instance
     public static func fromHeavenStem(_ heavenStem: HeavenStem) -> WealthGod {
-        return WealthGod(heavenStemIndex: heavenStem.getIndex())
+        return WealthGod(heavenStemIndex: heavenStem.index)
     }
 
     /// Create from day SixtyCycle
     /// - Parameter daySixtyCycle: Day SixtyCycle
     /// - Returns: WealthGod instance
     public static func fromDaySixtyCycle(_ daySixtyCycle: SixtyCycle) -> WealthGod {
-        return WealthGod(heavenStemIndex: daySixtyCycle.getHeavenStem().getIndex())
+        return WealthGod(heavenStemIndex: daySixtyCycle.heavenStem.index)
     }
 }

--- a/Sources/tyme/culture/god/YangNobleGod.swift
+++ b/Sources/tyme/culture/god/YangNobleGod.swift
@@ -23,23 +23,22 @@ public final class YangNobleGod: AbstractCulture {
         return YangNobleGod.DIRECTIONS[heavenStemIndex]
     }
 
-    /// Get direction
-    /// - Returns: Direction instance
-    public func getDirection() -> Direction {
-        return try! Direction.fromName(getName())
-    }
+    public var direction: Direction { try! Direction.fromName(getName()) }
+
+    @available(*, deprecated, renamed: "direction")
+    public func getDirection() -> Direction { direction }
 
     /// Create from heaven stem
     /// - Parameter heavenStem: Heaven stem
     /// - Returns: YangNobleGod instance
     public static func fromHeavenStem(_ heavenStem: HeavenStem) -> YangNobleGod {
-        return YangNobleGod(heavenStemIndex: heavenStem.getIndex())
+        return YangNobleGod(heavenStemIndex: heavenStem.index)
     }
 
     /// Create from day SixtyCycle
     /// - Parameter daySixtyCycle: Day SixtyCycle
     /// - Returns: YangNobleGod instance
     public static func fromDaySixtyCycle(_ daySixtyCycle: SixtyCycle) -> YangNobleGod {
-        return YangNobleGod(heavenStemIndex: daySixtyCycle.getHeavenStem().getIndex())
+        return YangNobleGod(heavenStemIndex: daySixtyCycle.heavenStem.index)
     }
 }

--- a/Sources/tyme/culture/god/YearGod.swift
+++ b/Sources/tyme/culture/god/YearGod.swift
@@ -10,28 +10,25 @@ public final class YearGod: AbstractCulture {
         "吊客", "病符"
     ]
 
-    private let yearGodIndex: Int
+    public let index: Int
 
     /// Initialize with index
     /// - Parameter index: Year god index (0-11)
     public init(index: Int) {
         var i = index % 12
         if i < 0 { i += 12 }
-        self.yearGodIndex = i
+        self.index = i
         super.init()
     }
 
     /// Get name
     /// - Returns: Year god name
     public override func getName() -> String {
-        return YearGod.NAMES[yearGodIndex]
+        return YearGod.NAMES[index]
     }
 
-    /// Get index
-    /// - Returns: Year god index
-    public func getIndex() -> Int {
-        return yearGodIndex
-    }
+    @available(*, deprecated, renamed: "index")
+    public func getIndex() -> Int { index }
 
     /// Create from index
     /// - Parameter index: Year god index
@@ -46,7 +43,7 @@ public final class YearGod: AbstractCulture {
     public static func fromEarthBranch(_ earthBranch: EarthBranch) -> [YearGod] {
         var gods: [YearGod] = []
         for i in 0..<12 {
-            gods.append(YearGod(index: (earthBranch.getIndex() + i) % 12))
+            gods.append(YearGod(index: (earthBranch.index + i) % 12))
         }
         return gods
     }

--- a/Sources/tyme/culture/god/YinNobleGod.swift
+++ b/Sources/tyme/culture/god/YinNobleGod.swift
@@ -23,23 +23,22 @@ public final class YinNobleGod: AbstractCulture {
         return YinNobleGod.DIRECTIONS[heavenStemIndex]
     }
 
-    /// Get direction
-    /// - Returns: Direction instance
-    public func getDirection() -> Direction {
-        return try! Direction.fromName(getName())
-    }
+    public var direction: Direction { try! Direction.fromName(getName()) }
+
+    @available(*, deprecated, renamed: "direction")
+    public func getDirection() -> Direction { direction }
 
     /// Create from heaven stem
     /// - Parameter heavenStem: Heaven stem
     /// - Returns: YinNobleGod instance
     public static func fromHeavenStem(_ heavenStem: HeavenStem) -> YinNobleGod {
-        return YinNobleGod(heavenStemIndex: heavenStem.getIndex())
+        return YinNobleGod(heavenStemIndex: heavenStem.index)
     }
 
     /// Create from day SixtyCycle
     /// - Parameter daySixtyCycle: Day SixtyCycle
     /// - Returns: YinNobleGod instance
     public static func fromDaySixtyCycle(_ daySixtyCycle: SixtyCycle) -> YinNobleGod {
-        return YinNobleGod(heavenStemIndex: daySixtyCycle.getHeavenStem().getIndex())
+        return YinNobleGod(heavenStemIndex: daySixtyCycle.heavenStem.index)
     }
 }

--- a/Sources/tyme/culture/nine/NineColdDay.swift
+++ b/Sources/tyme/culture/nine/NineColdDay.swift
@@ -11,16 +11,15 @@ public final class NineColdDay: AbstractCultureDay {
         super.init(culture: nine, dayIndex: dayIndex)
     }
 
-    /// Get nine period
-    /// - Returns: Nine instance
-    public func getNine() -> Nine {
-        return culture as! Nine
-    }
+    public var nine: Nine { culture as! Nine }
+
+    @available(*, deprecated, renamed: "nine")
+    public func getNine() -> Nine { nine }
 
     /// Get name
     /// - Returns: Nine day name (e.g., "一九第1天")
     public override func getName() -> String {
-        return "\(getNine().getName())第\(getDayIndex() + 1)天"
+        return "\(nine.getName())第\(dayIndex + 1)天"
     }
 
     /// Create from nine period and day index

--- a/Sources/tyme/culture/plumrain/PlumRain.swift
+++ b/Sources/tyme/culture/plumrain/PlumRain.swift
@@ -44,13 +44,12 @@ public final class PlumRain: LoopTyme {
         return PlumRain.fromIndex(nextIndex(n))
     }
 
-    /// Check if entering plum rain season
-    public func isEntering() -> Bool {
-        return index == 0
-    }
+    public var entering: Bool { index == 0 }
+    public var exiting: Bool { index == 1 }
 
-    /// Check if exiting plum rain season
-    public func isExiting() -> Bool {
-        return index == 1
-    }
+    @available(*, deprecated, renamed: "entering")
+    public func isEntering() -> Bool { entering }
+
+    @available(*, deprecated, renamed: "exiting")
+    public func isExiting() -> Bool { exiting }
 }

--- a/Sources/tyme/culture/plumrain/PlumRainDay.swift
+++ b/Sources/tyme/culture/plumrain/PlumRainDay.swift
@@ -11,16 +11,15 @@ public final class PlumRainDay: AbstractCultureDay {
         super.init(culture: plumRain, dayIndex: dayIndex)
     }
 
-    /// Get plum rain period
-    /// - Returns: PlumRain instance
-    public func getPlumRain() -> PlumRain {
-        return culture as! PlumRain
-    }
+    public var plumRain: PlumRain { culture as! PlumRain }
+
+    @available(*, deprecated, renamed: "plumRain")
+    public func getPlumRain() -> PlumRain { plumRain }
 
     /// Get name
     /// - Returns: Plum rain day name (e.g., "入梅第1天")
     public override func getName() -> String {
-        return "\(getPlumRain().getName())第\(getDayIndex() + 1)天"
+        return "\(plumRain.getName())第\(dayIndex + 1)天"
     }
 
     /// Create from plum rain and day index

--- a/Sources/tyme/culture/ren/MinorRen.swift
+++ b/Sources/tyme/culture/ren/MinorRen.swift
@@ -29,13 +29,12 @@ public final class MinorRen: LoopTyme {
         MinorRen.fromIndex(nextIndex(n))
     }
 
-    /// 吉凶
-    public func getLuck() -> Luck {
-        Luck.fromIndex(index % 2)
-    }
+    public var luck: Luck { Luck.fromIndex(index % 2) }
+    public var element: Element { Element.fromIndex([0, 4, 1, 3, 0, 2][index]) }
 
-    /// 五行
-    public func getElement() -> Element {
-        Element.fromIndex([0, 4, 1, 3, 0, 2][index])
-    }
+    @available(*, deprecated, renamed: "luck")
+    public func getLuck() -> Luck { luck }
+
+    @available(*, deprecated, renamed: "element")
+    public func getElement() -> Element { element }
 }

--- a/Sources/tyme/culture/taboo/DayTaboo.swift
+++ b/Sources/tyme/culture/taboo/DayTaboo.swift
@@ -3,8 +3,8 @@ import Foundation
 /// 日宜忌 (Day Taboo)
 /// Auspicious and inauspicious activities for a specific day
 public final class DayTaboo: AbstractCulture {
-    private let auspicious: [String]
-    private let inauspicious: [String]
+    public let auspicious: [String]
+    public let inauspicious: [String]
 
     /// Initialize with auspicious and inauspicious activities
     /// - Parameters:
@@ -22,30 +22,21 @@ public final class DayTaboo: AbstractCulture {
         return "宜:\(auspicious.joined(separator: " ")) 忌:\(inauspicious.joined(separator: " "))"
     }
 
-    /// Get auspicious activities
-    /// - Returns: List of auspicious activities
-    public func getAuspicious() -> [String] {
-        return auspicious
-    }
-
-    /// Get inauspicious activities
-    /// - Returns: List of inauspicious activities
-    public func getInauspicious() -> [String] {
-        return inauspicious
-    }
-
-    /// Get all taboos
-    /// - Returns: List of Taboo instances
-    public func getTaboos() -> [Taboo] {
+    public var taboos: [Taboo] {
         var result: [Taboo] = []
-        for name in auspicious {
-            result.append(Taboo.auspicious(name))
-        }
-        for name in inauspicious {
-            result.append(Taboo.inauspicious(name))
-        }
+        for name in auspicious { result.append(Taboo.auspicious(name)) }
+        for name in inauspicious { result.append(Taboo.inauspicious(name)) }
         return result
     }
+
+    @available(*, deprecated, renamed: "auspicious")
+    public func getAuspicious() -> [String] { auspicious }
+
+    @available(*, deprecated, renamed: "inauspicious")
+    public func getInauspicious() -> [String] { inauspicious }
+
+    @available(*, deprecated, renamed: "taboos")
+    public func getTaboos() -> [Taboo] { taboos }
 
     /// Check if an activity is auspicious
     /// - Parameter activity: Activity name

--- a/Sources/tyme/culture/taboo/Taboo.swift
+++ b/Sources/tyme/culture/taboo/Taboo.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Auspicious and inauspicious activities for a day
 public final class Taboo: AbstractCulture {
     private let tabooName: String
-    private let luck: Luck
+    public let luck: Luck
 
     /// Initialize with name and luck
     /// - Parameters:
@@ -22,21 +22,17 @@ public final class Taboo: AbstractCulture {
         return tabooName
     }
 
-    /// Get luck
-    /// - Returns: Luck instance
-    public func getLuck() -> Luck {
-        return luck
-    }
+    public var auspicious: Bool { luck.auspicious }
+    public var inauspicious: Bool { luck.inauspicious }
 
-    /// Check if auspicious (宜)
-    public func isAuspicious() -> Bool {
-        return luck.isAuspicious()
-    }
+    @available(*, deprecated, renamed: "luck")
+    public func getLuck() -> Luck { luck }
 
-    /// Check if inauspicious (忌)
-    public func isInauspicious() -> Bool {
-        return luck.isInauspicious()
-    }
+    @available(*, deprecated, renamed: "auspicious")
+    public func isAuspicious() -> Bool { auspicious }
+
+    @available(*, deprecated, renamed: "inauspicious")
+    public func isInauspicious() -> Bool { inauspicious }
 
     /// Create auspicious taboo
     /// - Parameter name: Taboo name

--- a/Tests/tymeTests/CultureTests.swift
+++ b/Tests/tymeTests/CultureTests.swift
@@ -25,8 +25,8 @@ import Testing
         #expect(nextRat.getName() == "鼠")
         #expect(nextRat.index == 0)
 
-        // Test getEarthBranch
-        let ratBranch = rat.getEarthBranch()
+        // Test earthBranch
+        let ratBranch = rat.earthBranch
         #expect(ratBranch.getName() == "子")
     }
     @Test func testPengZuHeavenStem() throws {
@@ -118,24 +118,24 @@ import Testing
         let jiaZi = SixtyCycle.fromIndex(0)
         let pengZu1 = PengZu.fromSixtyCycle(jiaZi)
         #expect(pengZu1.getName() == "甲不开仓财物耗散 子不问卜自惹祸殃")
-        #expect(pengZu1.getHeavenStemTaboo() == "甲不开仓财物耗散")
-        #expect(pengZu1.getEarthBranchTaboo() == "子不问卜自惹祸殃")
+        #expect(pengZu1.heavenStemTaboo == "甲不开仓财物耗散")
+        #expect(pengZu1.earthBranchTaboo == "子不问卜自惹祸殃")
 
         // Test with SixtyCycle 乙丑
         let yiChou = SixtyCycle.fromIndex(1)
         let pengZu2 = PengZu.fromSixtyCycle(yiChou)
         #expect(pengZu2.getName() == "乙不栽植千株不长 丑不冠带主不还乡")
 
-        // Test getTaboos
-        let taboos = pengZu1.getTaboos()
+        // Test taboos
+        let taboos = pengZu1.taboos
         #expect(taboos.count == 2)
         #expect(taboos[0] == "甲不开仓财物耗散")
         #expect(taboos[1] == "子不问卜自惹祸殃")
 
-        // Test getPengZuHeavenStem and getPengZuEarthBranch
-        let heavenStem = pengZu1.getPengZuHeavenStem()
+        // Test pengZuHeavenStem and pengZuEarthBranch
+        let heavenStem = pengZu1.pengZuHeavenStem
         #expect(heavenStem.index == 0)
-        let earthBranch = pengZu1.getPengZuEarthBranch()
+        let earthBranch = pengZu1.pengZuEarthBranch
         #expect(earthBranch.index == 0)
 
         // Test with SixtyCycle 癸亥 (index 59, last one)
@@ -151,14 +151,14 @@ import Testing
         let ji = Luck.fromIndex(0)
         #expect(ji.getName() == "吉")
         #expect(ji.index == 0)
-        #expect(ji.isAuspicious())
-        #expect(!ji.isInauspicious())
+        #expect(ji.auspicious)
+        #expect(!ji.inauspicious)
 
         let xiong = Luck.fromIndex(1)
         #expect(xiong.getName() == "凶")
         #expect(xiong.index == 1)
-        #expect(!xiong.isAuspicious())
-        #expect(xiong.isInauspicious())
+        #expect(!xiong.auspicious)
+        #expect(xiong.inauspicious)
 
         // Test fromName
         let ji2 = try Luck.fromName("吉")
@@ -192,8 +192,8 @@ import Testing
         let nextSun = saturn.next(1)
         #expect(nextSun.getName() == "日")
 
-        // Test getWeek
-        let sunWeek = sun.getWeek()
+        // Test week
+        let sunWeek = sun.week
         #expect(sunWeek.getName() == "日")
     }
     @Test func testSixStar() throws {
@@ -258,10 +258,10 @@ import Testing
         let huangdao2 = try Ecliptic.fromName("黄道")
         #expect(huangdao2.index == 0)
 
-        // Test getLuck
-        let luck1 = huangdao.getLuck()
+        // Test luck
+        let luck1 = huangdao.luck
         #expect(luck1.getName() == "吉")
-        let luck2 = heidao.getLuck()
+        let luck2 = heidao.luck
         #expect(luck2.getName() == "凶")
 
         // Test next
@@ -290,14 +290,14 @@ import Testing
         let nextQinglong = gouchen.next(1)
         #expect(nextQinglong.getName() == "青龙")
 
-        // Test getEcliptic - 青龙 is 黄道
-        let ecliptic1 = qinglong.getEcliptic()
+        // Test ecliptic - 青龙 is 黄道
+        let ecliptic1 = qinglong.ecliptic
         #expect(ecliptic1.getName() == "黄道")
         #expect(qinglong.isAuspicious())
 
-        // Test getEcliptic - 天刑 is 黑道
+        // Test ecliptic - 天刑 is 黑道
         let tianxing = TwelveStar.fromIndex(2)
-        let ecliptic2 = tianxing.getEcliptic()
+        let ecliptic2 = tianxing.ecliptic
         #expect(ecliptic2.getName() == "黑道")
         #expect(tianxing.isInauspicious())
     }
@@ -323,12 +323,12 @@ import Testing
         let nextEast = south.next(1)
         #expect(nextEast.getName() == "东")
 
-        // Test getDirection
-        let direction = east.getDirection()
+        // Test direction
+        let direction = east.direction
         #expect(direction.getName() == "东")
 
-        // Test getBeast
-        let beast = east.getBeast()
+        // Test beast
+        let beast = east.beast
         #expect(beast.getName() == "青龙")
     }
     @Test func testBeast() throws {
@@ -353,8 +353,8 @@ import Testing
         let nextQinglong = zhuque.next(1)
         #expect(nextQinglong.getName() == "青龙")
 
-        // Test getZone
-        let zone = qinglong.getZone()
+        // Test zone
+        let zone = qinglong.zone
         #expect(zone.getName() == "东")
     }
     @Test func testLand() throws {
@@ -379,8 +379,8 @@ import Testing
         let nextXuantian = yantian.next(1)
         #expect(nextXuantian.getName() == "玄天")
 
-        // Test getDirection
-        let direction = xuantian.getDirection()
+        // Test direction
+        let direction = xuantian.direction
         #expect(direction.getName() == "北")
     }
     @Test func testAnimal() throws {
@@ -405,8 +405,8 @@ import Testing
         let nextJiao = yin.next(1)
         #expect(nextJiao.getName() == "蛟")
 
-        // Test getTwentyEightStar
-        let star = jiao.getTwentyEightStar()
+        // Test twentyEightStar
+        let star = jiao.twentyEightStar
         #expect(star.getName() == "角")
     }
     @Test func testTwentyEightStar() throws {
@@ -431,35 +431,35 @@ import Testing
         let nextJiao = zhen.next(1)
         #expect(nextJiao.getName() == "角")
 
-        // Test getZone - first 7 stars are in East (东)
-        let zone = jiao.getZone()
+        // Test zone - first 7 stars are in East (东)
+        let zone = jiao.zone
         #expect(zone.getName() == "东")
 
-        // Test getZone - stars 7-13 are in North (北)
+        // Test zone - stars 7-13 are in North (北)
         let dou = TwentyEightStar.fromIndex(7)
-        let northZone = dou.getZone()
+        let northZone = dou.zone
         #expect(northZone.getName() == "北")
 
-        // Test getAnimal
-        let animal = jiao.getAnimal()
+        // Test animal
+        let animal = jiao.animal
         #expect(animal.getName() == "蛟")
 
-        // Test getLand
-        let land = jiao.getLand()
+        // Test land
+        let land = jiao.land
         #expect(land.getName() == "钧天")
 
-        // Test getLuck - 角 is 吉
-        let luck = jiao.getLuck()
+        // Test luck - 角 is 吉
+        let luck = jiao.luck
         #expect(luck.getName() == "吉")
         #expect(jiao.isAuspicious())
 
-        // Test getLuck - 亢 is 凶
-        let luck2 = kang.getLuck()
+        // Test luck - 亢 is 凶
+        let luck2 = kang.luck
         #expect(luck2.getName() == "凶")
         #expect(kang.isInauspicious())
 
-        // Test getSevenStar
-        let sevenStar = jiao.getSevenStar()
+        // Test sevenStar
+        let sevenStar = jiao.sevenStar
         #expect(sevenStar.getName() == "木")
     }
     @Test func testDuty() throws {
@@ -514,7 +514,7 @@ import Testing
             let sound = Sound.fromIndex(i)
             #expect(sound.getName() == expectedNames[i])
             #expect(sound.index == i)
-            #expect(sound.getWuXing() == expectedWuXing[i])
+            #expect(sound.wuXing == expectedWuXing[i])
         }
 
         // Test fromName
@@ -530,8 +530,8 @@ import Testing
         let nextGong = yu.next(1)
         #expect(nextGong.getName() == "宫")
 
-        // Test getElement
-        let element = gong.getElement()
+        // Test element
+        let element = gong.element
         #expect(element.getName() == "土")
     }
     @Test func testPhase() throws {
@@ -578,12 +578,12 @@ import Testing
         let nextQiuYinJie = liTingChu.next(1)
         #expect(nextQiuYinJie.getName() == "蚯蚓结")
 
-        // Test getThreePhenology
-        let threePhenology = qiuYinJie.getThreePhenology()
+        // Test threePhenology
+        let threePhenology = qiuYinJie.threePhenology
         #expect(threePhenology.getName() == "初候")
 
-        // Test getSolarTermIndex
-        #expect(qiuYinJie.getSolarTermIndex() == 0)
+        // Test solarTermIndex
+        #expect(qiuYinJie.solarTermIndex == 0)
     }
     @Test func testThreePhenology() throws {
         // Test all three phenology periods
@@ -614,7 +614,7 @@ import Testing
             let phaseDay = PhaseDay.fromIndex(i)
             #expect(phaseDay.getName() == expectedNames[i])
             #expect(phaseDay.index == i)
-            #expect(phaseDay.getDayNumber() == i + 1)
+            #expect(phaseDay.dayNumber == i + 1)
         }
 
         // Test fromName
@@ -652,8 +652,8 @@ import Testing
         let nextJia = gui.next(1)
         #expect(nextJia.getName() == "甲")
 
-        // Test getHeavenStem
-        let heavenStem = jia.getHeavenStem()
+        // Test heavenStem
+        let heavenStem = jia.heavenStem
         #expect(heavenStem.getName() == "甲")
     }
     @Test func testTerrain() throws {
@@ -678,18 +678,18 @@ import Testing
         let nextChangSheng = yang.next(1)
         #expect(nextChangSheng.getName() == "长生")
 
-        // Test isProsperous
-        #expect(changSheng.isProsperous())
-        #expect(!muYu.isProsperous())
+        // Test prosperous
+        #expect(changSheng.prosperous)
+        #expect(!muYu.prosperous)
 
-        // Test isDeclining
+        // Test declining
         let shuai = Terrain.fromIndex(5)
-        #expect(shuai.isDeclining())
-        #expect(!changSheng.isDeclining())
+        #expect(shuai.declining)
+        #expect(!changSheng.declining)
 
-        // Test isNurturing
-        #expect(muYu.isNurturing())
-        #expect(!changSheng.isNurturing())
+        // Test nurturing
+        #expect(muYu.nurturing)
+        #expect(!changSheng.nurturing)
     }
     @Test func testNaYin() throws {
         // Test first few NaYin
@@ -699,7 +699,7 @@ import Testing
             let naYin = NaYin.fromIndex(i)
             #expect(naYin.getName() == expectedNames[i])
             #expect(naYin.index == i)
-            #expect(naYin.getWuXing() == expectedWuXing[i])
+            #expect(naYin.wuXing == expectedWuXing[i])
         }
 
         // Test fromName
@@ -723,8 +723,8 @@ import Testing
         let naYin2 = NaYin.fromSixtyCycle(2)
         #expect(naYin2.getName() == "炉中火")
 
-        // Test getElement
-        let element = haiZhongJin.getElement()
+        // Test element
+        let element = haiZhongJin.element
         #expect(element.getName() == "金")
     }
     @Test func testSixty() throws {
@@ -749,20 +749,20 @@ import Testing
         let nextJiaZi = guiHai.next(1)
         #expect(nextJiaZi.getName() == "甲子")
 
-        // Test getSixtyCycle
-        let sixtyCycle = jiaZi.getSixtyCycle()
+        // Test sixtyCycle
+        let sixtyCycle = jiaZi.sixtyCycle
         #expect(sixtyCycle.getName() == "甲子")
 
-        // Test getNaYin
-        let naYin = jiaZi.getNaYin()
+        // Test naYin
+        let naYin = jiaZi.naYin
         #expect(naYin.getName() == "海中金")
 
-        // Test getHeavenStem
-        let heavenStem = jiaZi.getHeavenStem()
+        // Test heavenStem
+        let heavenStem = jiaZi.heavenStem
         #expect(heavenStem.getName() == "甲")
 
-        // Test getEarthBranch
-        let earthBranch = jiaZi.getEarthBranch()
+        // Test earthBranch
+        let earthBranch = jiaZi.earthBranch
         #expect(earthBranch.getName() == "子")
     }
     @Test func testTen() throws {
@@ -772,7 +772,7 @@ import Testing
             let ten = Ten.fromIndex(i)
             #expect(ten.getName() == expectedNames[i])
             #expect(ten.index == i)
-            #expect(ten.getDayNumber() == i + 1)
+            #expect(ten.dayNumber == i + 1)
         }
 
         // Test fromName
@@ -795,7 +795,7 @@ import Testing
             let twenty = Twenty.fromIndex(i)
             #expect(twenty.getName() == expectedNames[i])
             #expect(twenty.index == i)
-            #expect(twenty.getDayNumber() == i + 1)
+            #expect(twenty.dayNumber == i + 1)
         }
 
         // Test fromName
@@ -955,8 +955,8 @@ import Testing
     @Test func testDogDay() throws {
         let dog = Dog.fromIndex(0)
         let dogDay = DogDay.fromDog(dog, 0)
-        #expect(dogDay.getDog().getName() == "初伏")
-        #expect(dogDay.getDayIndex() == 0)
+        #expect(dogDay.dog.getName() == "初伏")
+        #expect(dogDay.dayIndex == 0)
         #expect(dogDay.getName() == "初伏第1天")
 
         let dogDay2 = DogDay.fromDog(dog, 4)
@@ -987,8 +987,8 @@ import Testing
     @Test func testNineColdDay() throws {
         let nine = Nine.fromIndex(0)
         let nineDay = NineColdDay.fromNine(nine, 0)
-        #expect(nineDay.getNine().getName() == "一九")
-        #expect(nineDay.getDayIndex() == 0)
+        #expect(nineDay.nine.getName() == "一九")
+        #expect(nineDay.dayIndex == 0)
         #expect(nineDay.getName() == "一九第1天")
 
         let nineDay2 = NineColdDay.fromNine(nine, 8)
@@ -998,13 +998,13 @@ import Testing
         // Test both plum rain periods
         let ruMei = PlumRain.fromIndex(0)
         #expect(ruMei.getName() == "入梅")
-        #expect(ruMei.isEntering())
-        #expect(!ruMei.isExiting())
+        #expect(ruMei.entering)
+        #expect(!ruMei.exiting)
 
         let chuMei = PlumRain.fromIndex(1)
         #expect(chuMei.getName() == "出梅")
-        #expect(!chuMei.isEntering())
-        #expect(chuMei.isExiting())
+        #expect(!chuMei.entering)
+        #expect(chuMei.exiting)
 
         // Test next
         let next = ruMei.next(1)
@@ -1013,22 +1013,22 @@ import Testing
     @Test func testPlumRainDay() throws {
         let plumRain = PlumRain.fromIndex(0)
         let plumRainDay = PlumRainDay.fromPlumRain(plumRain, 0)
-        #expect(plumRainDay.getPlumRain().getName() == "入梅")
-        #expect(plumRainDay.getDayIndex() == 0)
+        #expect(plumRainDay.plumRain.getName() == "入梅")
+        #expect(plumRainDay.dayIndex == 0)
         #expect(plumRainDay.getName() == "入梅第1天")
     }
     @Test func testTaboo() throws {
         // Test auspicious taboo
         let auspicious = Taboo.auspicious("祭祀")
         #expect(auspicious.getName() == "祭祀")
-        #expect(auspicious.isAuspicious())
-        #expect(!auspicious.isInauspicious())
+        #expect(auspicious.auspicious)
+        #expect(!auspicious.inauspicious)
 
         // Test inauspicious taboo
         let inauspicious = Taboo.inauspicious("动土")
         #expect(inauspicious.getName() == "动土")
-        #expect(!inauspicious.isAuspicious())
-        #expect(inauspicious.isInauspicious())
+        #expect(!inauspicious.auspicious)
+        #expect(inauspicious.inauspicious)
     }
     @Test func testMinorRen() throws {
         // Test all six names
@@ -1045,22 +1045,22 @@ import Testing
     }
     @Test func testMinorRenLuck() throws {
         // Even index = 吉, Odd index = 凶
-        #expect("吉" == MinorRen.fromIndex(0).getLuck().getName()) // 大安
-        #expect("凶" == MinorRen.fromIndex(1).getLuck().getName()) // 留连
-        #expect("吉" == MinorRen.fromIndex(2).getLuck().getName()) // 速喜
-        #expect("凶" == MinorRen.fromIndex(3).getLuck().getName()) // 赤口
-        #expect("吉" == MinorRen.fromIndex(4).getLuck().getName()) // 小吉
-        #expect("凶" == MinorRen.fromIndex(5).getLuck().getName()) // 空亡
+        #expect("吉" == MinorRen.fromIndex(0).luck.getName()) // 大安
+        #expect("凶" == MinorRen.fromIndex(1).luck.getName()) // 留连
+        #expect("吉" == MinorRen.fromIndex(2).luck.getName()) // 速喜
+        #expect("凶" == MinorRen.fromIndex(3).luck.getName()) // 赤口
+        #expect("吉" == MinorRen.fromIndex(4).luck.getName()) // 小吉
+        #expect("凶" == MinorRen.fromIndex(5).luck.getName()) // 空亡
     }
     @Test func testMinorRenElement() throws {
         // Mapping: [0,4,1,3,0,2] → Element.NAMES["木","火","土","金","水"] index
         // [0,4,1,3,0,2] → [木,水,火,金,木,土]
-        #expect("木" == MinorRen.fromIndex(0).getElement().getName()) // 大安
-        #expect("水" == MinorRen.fromIndex(1).getElement().getName()) // 留连
-        #expect("火" == MinorRen.fromIndex(2).getElement().getName()) // 速喜
-        #expect("金" == MinorRen.fromIndex(3).getElement().getName()) // 赤口
-        #expect("木" == MinorRen.fromIndex(4).getElement().getName()) // 小吉
-        #expect("土" == MinorRen.fromIndex(5).getElement().getName()) // 空亡
+        #expect("木" == MinorRen.fromIndex(0).element.getName()) // 大安
+        #expect("水" == MinorRen.fromIndex(1).element.getName()) // 留连
+        #expect("火" == MinorRen.fromIndex(2).element.getName()) // 速喜
+        #expect("金" == MinorRen.fromIndex(3).element.getName()) // 赤口
+        #expect("木" == MinorRen.fromIndex(4).element.getName()) // 小吉
+        #expect("土" == MinorRen.fromIndex(5).element.getName()) // 空亡
     }
     @Test func testMinorRenNext() throws {
         let daAn = MinorRen.fromIndex(0)
@@ -1084,17 +1084,17 @@ import Testing
     }
     @Test func testElementYinYang() throws {
         // 木=阳, 火=阴, 土=阳, 金=阴, 水=阳
-        #expect("阳" == Element.fromIndex(0).getYinYang()) // 木
-        #expect("阴" == Element.fromIndex(1).getYinYang()) // 火
-        #expect("阳" == Element.fromIndex(2).getYinYang()) // 土
-        #expect("阴" == Element.fromIndex(3).getYinYang()) // 金
-        #expect("阳" == Element.fromIndex(4).getYinYang()) // 水
+        #expect("阳" == Element.fromIndex(0).yinYang) // 木
+        #expect("阴" == Element.fromIndex(1).yinYang) // 火
+        #expect("阳" == Element.fromIndex(2).yinYang) // 土
+        #expect("阴" == Element.fromIndex(3).yinYang) // 金
+        #expect("阳" == Element.fromIndex(4).yinYang) // 水
     }
     @Test func testPhenologyDay() {
         let p = Phenology.fromIndex(0)
         let day = PhenologyDay(phenology: p, dayIndex: 2)
-        #expect(day.getPhenology().getName() == "蚯蚓结")
-        #expect(day.getDayIndex() == 2)
+        #expect(day.phenology.getName() == "蚯蚓结")
+        #expect(day.dayIndex == 2)
         #expect(day.getName() == "蚯蚓结")
         #expect(day.description == "蚯蚓结第3天")
     }
@@ -1102,10 +1102,10 @@ import Testing
         let e = try RabByungElement(index: 3) // 金→铁
         #expect(e.getName() == "铁")
         #expect(e.index == 3)
-        #expect(e.getReinforce().getName() == "水")  // 铁生水
-        #expect(e.getRestrain().getName() == "木")   // 铁克木
-        #expect(e.getReinforced().getName() == "土") // 土生铁
-        #expect(e.getRestrained().getName() == "火") // 火克铁
+        #expect(e.reinforce.getName() == "水")  // 铁生水
+        #expect(e.restrain.getName() == "木")   // 铁克木
+        #expect(e.reinforced.getName() == "土") // 土生铁
+        #expect(e.restrained.getName() == "火") // 火克铁
 
         let e2 = try RabByungElement.fromName("铁")
         #expect(e2.index == 3)

--- a/Tests/tymeTests/EightCharTests.swift
+++ b/Tests/tymeTests/EightCharTests.swift
@@ -8,17 +8,17 @@ import Testing
         let yearBranch = EarthBranch.fromIndex(0) // 子
         let monthBranch = EarthBranch.fromIndex(2) // 寅
         let lifePalace = LifePalace.fromYearMonth(yearBranch, monthBranch)
-        _ = lifePalace.getSixtyCycle()
-        _ = lifePalace.getHeavenStem()
-        _ = lifePalace.getEarthBranch()
+        _ = lifePalace.sixtyCycle
+        _ = lifePalace.heavenStem
+        _ = lifePalace.earthBranch
     }
     @Test func testBodyPalace() throws {
         let yearBranch = EarthBranch.fromIndex(0) // 子
         let hourBranch = EarthBranch.fromIndex(6) // 午
         let bodyPalace = BodyPalace.fromYearHour(yearBranch, hourBranch)
-        _ = bodyPalace.getSixtyCycle()
-        _ = bodyPalace.getHeavenStem()
-        _ = bodyPalace.getEarthBranch()
+        _ = bodyPalace.sixtyCycle
+        _ = bodyPalace.heavenStem
+        _ = bodyPalace.earthBranch
     }
     @Test func testDefaultEightCharProvider() throws {
         let provider = DefaultEightCharProvider()

--- a/Tests/tymeTests/FetusTests.swift
+++ b/Tests/tymeTests/FetusTests.swift
@@ -6,26 +6,26 @@ import Testing
         // Test Fetus from SixtyCycle
         let sixtyCycle = SixtyCycle.fromIndex(0)
         let fetus = Fetus.fromSixtyCycle(sixtyCycle)
-        _ = fetus.getPosition()
-        _ = fetus.getDirection()
+        _ = fetus.position
+        _ = fetus.direction
         _ = fetus.getName()
 
         // Test fromIndex
         let fetus2 = Fetus.fromIndex(30)
-        #expect(fetus2.getSixtyCycleIndex() == 30)
+        #expect(fetus2.sixtyCycleIndex == 30)
     }
     @Test func testFetusOrigin() throws {
         // Test FetusOrigin from month pillar
         let monthPillar = SixtyCycle.fromIndex(0) // 甲子
         let fetusOrigin = FetusOrigin.fromMonthPillar(monthPillar)
-        _ = fetusOrigin.getSixtyCycle()
-        _ = fetusOrigin.getHeavenStem()
-        _ = fetusOrigin.getEarthBranch()
+        _ = fetusOrigin.sixtyCycle
+        _ = fetusOrigin.heavenStem
+        _ = fetusOrigin.earthBranch
     }
     @Test func testFetusDay() throws {
-        #expect("厨灶炉 外正南" == (try SolarDay.fromYmd(2021, 11, 13).getLunarDay().getFetusDay().getName()))
-        #expect("碓磨厕 外东南" == (try SolarDay.fromYmd(2021, 11, 12).getLunarDay().getFetusDay().getName()))
-        #expect("仓库炉 外西南" == (try SolarDay.fromYmd(2011, 11, 12).getLunarDay().getFetusDay().getName()))
+        #expect("厨灶炉 外正南" == (try SolarDay.fromYmd(2021, 11, 13).lunarDay.fetusDay.getName()))
+        #expect("碓磨厕 外东南" == (try SolarDay.fromYmd(2021, 11, 12).lunarDay.fetusDay.getName()))
+        #expect("仓库炉 外西南" == (try SolarDay.fromYmd(2011, 11, 12).lunarDay.fetusDay.getName()))
     }
     @Test func testFetusDayFromSixtyCycleDay() throws {
         let scd = try SixtyCycleDay.fromYmd(2021, 11, 13)
@@ -34,9 +34,9 @@ import Testing
     }
     @Test func testFetusMonth() throws {
         let m1 = try LunarMonth.fromYm(2021, 11)
-        #expect(m1.getFetus()!.getName() == "占灶炉")
+        #expect(m1.fetus!.getName() == "占灶炉")
         let m2 = try LunarMonth.fromYm(2021, 1)
-        #expect(m2.getFetus()!.getName() == "占房床")
+        #expect(m2.fetus!.getName() == "占房床")
     }
     @Test func testFetusHeavenStem() throws {
         #expect(FetusHeavenStem(index: 0).getName() == "门")

--- a/Tests/tymeTests/GodTests.swift
+++ b/Tests/tymeTests/GodTests.swift
@@ -31,26 +31,26 @@ import Testing
         let god = God(type: godType, luck: luck, name: "天德")
 
         #expect(god.getName() == "天德")
-        #expect(god.getGodType().getName() == "日")
-        #expect(god.getLuck().getName() == "吉")
-        #expect(god.isAuspicious())
-        #expect(!god.isInauspicious())
+        #expect(god.godType.getName() == "日")
+        #expect(god.luck.getName() == "吉")
+        #expect(god.auspicious)
+        #expect(!god.inauspicious)
 
         // Test inauspicious god
         let badLuck = Luck.fromIndex(1) // 凶
         let badGod = God(type: godType, luck: badLuck, name: "天刑")
-        #expect(!badGod.isAuspicious())
-        #expect(badGod.isInauspicious())
+        #expect(!badGod.auspicious)
+        #expect(badGod.inauspicious)
     }
     @Test func testDayTaboo() throws {
         let dayTaboo = DayTaboo(auspicious: ["祭祀", "祈福"], inauspicious: ["动土", "破土"])
-        #expect(dayTaboo.getAuspicious().count == 2)
-        #expect(dayTaboo.getInauspicious().count == 2)
+        #expect(dayTaboo.auspicious.count == 2)
+        #expect(dayTaboo.inauspicious.count == 2)
         #expect(dayTaboo.isAuspicious("祭祀"))
         #expect(dayTaboo.isInauspicious("动土"))
         #expect(!dayTaboo.isAuspicious("动土"))
 
-        let taboos = dayTaboo.getTaboos()
+        let taboos = dayTaboo.taboos
         #expect(taboos.count == 4)
     }
     @Test func testYearGod() throws {
@@ -59,7 +59,7 @@ import Testing
         for i in 0..<12 {
             let yearGod = YearGod.fromIndex(i)
             #expect(yearGod.getName() == expectedNames[i])
-            #expect(yearGod.getIndex() == i)
+            #expect(yearGod.index == i)
         }
 
         // Test fromEarthBranch
@@ -73,23 +73,23 @@ import Testing
         for i in 0..<5 {
             let monthGod = MonthGod.fromIndex(i)
             #expect(monthGod.getName() == expectedNames[i])
-            #expect(monthGod.getIndex() == i)
+            #expect(monthGod.index == i)
         }
     }
     @Test func testDayGod() throws {
         // Test auspicious day god
         let auspicious = DayGod.auspicious("天德")
         #expect(auspicious.getName() == "天德")
-        #expect(auspicious.getIsAuspicious())
-        #expect(!auspicious.getIsInauspicious())
-        #expect(auspicious.getLuck().getName() == "吉")
+        #expect(auspicious.auspicious)
+        #expect(!auspicious.inauspicious)
+        #expect(auspicious.luck.getName() == "吉")
 
         // Test inauspicious day god
         let inauspicious = DayGod.inauspicious("月破")
         #expect(inauspicious.getName() == "月破")
-        #expect(!inauspicious.getIsAuspicious())
-        #expect(inauspicious.getIsInauspicious())
-        #expect(inauspicious.getLuck().getName() == "凶")
+        #expect(!inauspicious.auspicious)
+        #expect(inauspicious.inauspicious)
+        #expect(inauspicious.luck.getName() == "凶")
     }
     @Test func testHourGod() throws {
         // Test first few hour gods
@@ -97,7 +97,7 @@ import Testing
         for i in 0..<5 {
             let hourGod = HourGod.fromIndex(i)
             #expect(hourGod.getName() == expectedNames[i])
-            #expect(hourGod.getIndex() == i)
+            #expect(hourGod.index == i)
         }
     }
     @Test func testJoyGod() throws {
@@ -105,7 +105,7 @@ import Testing
         let heavenStem = HeavenStem.fromIndex(0) // 甲
         let joyGod = JoyGod.fromHeavenStem(heavenStem)
         #expect(joyGod.getName() == "东北")
-        _ = joyGod.getDirection()
+        _ = joyGod.direction
 
         // Test from SixtyCycle
         let sixtyCycle = SixtyCycle.fromIndex(0) // 甲子
@@ -117,7 +117,7 @@ import Testing
         let heavenStem = HeavenStem.fromIndex(0) // 甲
         let wealthGod = WealthGod.fromHeavenStem(heavenStem)
         #expect(wealthGod.getName() == "东南")
-        _ = wealthGod.getDirection()
+        _ = wealthGod.direction
 
         // Test from SixtyCycle
         let sixtyCycle = SixtyCycle.fromIndex(0) // 甲子
@@ -129,26 +129,26 @@ import Testing
         let heavenStem = HeavenStem.fromIndex(0) // 甲
         let fortuneGod = FortuneGod.fromHeavenStem(heavenStem)
         #expect(fortuneGod.getName() == "东南")
-        _ = fortuneGod.getDirection()
+        _ = fortuneGod.direction
     }
     @Test func testYangNobleGod() throws {
         // Test yang noble god directions
         let heavenStem = HeavenStem.fromIndex(0) // 甲
         let yangNobleGod = YangNobleGod.fromHeavenStem(heavenStem)
         #expect(yangNobleGod.getName() == "西南")
-        _ = yangNobleGod.getDirection()
+        _ = yangNobleGod.direction
     }
     @Test func testYinNobleGod() throws {
         // Test yin noble god directions
         let heavenStem = HeavenStem.fromIndex(0) // 甲
         let yinNobleGod = YinNobleGod.fromHeavenStem(heavenStem)
         #expect(yinNobleGod.getName() == "东北")
-        _ = yinNobleGod.getDirection()
+        _ = yinNobleGod.direction
     }
     @Test func testGodLookup() throws {
         // Test God lookup for a known date (2024-01-01)
         let day = try SixtyCycleDay(year: 2024, month: 1, day: 1)
-        let gods = day.getGods()
+        let gods = day.gods
 
         // Verify gods list is not empty
         #expect(!gods.isEmpty)
@@ -157,29 +157,29 @@ import Testing
         for god in gods {
             #expect(!god.getName().isEmpty)
             // Verify each god has a valid luck status (auspicious or inauspicious)
-            let isValid = god.isAuspicious() || god.isInauspicious()
+            let isValid = god.auspicious || god.inauspicious
             #expect(isValid)
         }
     }
     @Test func testDayRecommends() throws {
         let day = try SixtyCycleDay(year: 2024, month: 1, day: 1)
-        let recommends = day.getRecommends()
+        let recommends = day.recommends
 
         // Verify all returned Taboo objects are marked as auspicious
         for taboo in recommends {
-            #expect(taboo.isAuspicious())
-            #expect(!taboo.isInauspicious())
+            #expect(taboo.auspicious)
+            #expect(!taboo.inauspicious)
             #expect(!taboo.getName().isEmpty)
         }
     }
     @Test func testDayAvoids() throws {
         let day = try SixtyCycleDay(year: 2024, month: 1, day: 1)
-        let avoids = day.getAvoids()
+        let avoids = day.avoids
 
         // Verify all returned Taboo objects are marked as inauspicious
         for taboo in avoids {
-            #expect(taboo.isInauspicious())
-            #expect(!taboo.isAuspicious())
+            #expect(taboo.inauspicious)
+            #expect(!taboo.auspicious)
             #expect(!taboo.getName().isEmpty)
         }
     }

--- a/Tests/tymeTests/RegressionTests.swift
+++ b/Tests/tymeTests/RegressionTests.swift
@@ -14,17 +14,17 @@ import Testing
     }
     @Test func testGetLunarDayBoundaryDates() throws {
         let d1 = try SolarDay.fromYmd(1, 2, 12)
-        #expect(d1.getLunarDay().getDay() >= 1 && d1.getLunarDay().getDay() <= 30)
+        #expect(d1.lunarDay.day >= 1 && d1.lunarDay.day <= 30)
 
         let d2 = try SolarDay.fromYmd(100, 1, 1)
-        #expect(d2.getLunarDay().getDay() >= 1 && d2.getLunarDay().getDay() <= 30)
+        #expect(d2.lunarDay.day >= 1 && d2.lunarDay.day <= 30)
 
         // 2024-02-10 is lunar new year
-        #expect("初一" == (try SolarDay.fromYmd(2024, 2, 10).getLunarDay().getName()))
+        #expect("初一" == (try SolarDay.fromYmd(2024, 2, 10).lunarDay.getName()))
     }
     @Test func testGetLunarDayLeapMonth() throws {
         let d = try SolarDay.fromYmd(2023, 4, 20)
-        #expect(d.getLunarDay().getDay() >= 1 && d.getLunarDay().getDay() <= 30)
+        #expect(d.lunarDay.day >= 1 && d.lunarDay.day <= 30)
     }
     @Test func testElementNamesOrder() throws {
         #expect(Element.fromIndex(0).getName() == "木")
@@ -34,27 +34,27 @@ import Testing
         #expect(Element.fromIndex(4).getName() == "水")
     }
     @Test func testNineStarElementUnaffected() throws {
-        #expect(NineStar.fromIndex(0).getElement().getName() == "水")
+        #expect(NineStar.fromIndex(0).element.getName() == "水")
     }
     @Test func testSoundElementUnaffected() throws {
-        #expect(!Sound.fromIndex(0).getElement().getName().isEmpty)
+        #expect(!Sound.fromIndex(0).element.getName().isEmpty)
     }
     @Test func testGodTabooDataIntegrity() throws {
         // Test specific date from Issue #42
         let day = try SixtyCycleDay(year: 2024, month: 12, day: 1)
-        let gods = day.getGods()
+        let gods = day.gods
         #expect(gods.count > 0)
-        _ = day.getRecommends()
-        _ = day.getAvoids()
+        _ = day.recommends
+        _ = day.avoids
     }
     @Test func testGodTabooFullYear2024() throws {
         let daysInMonth = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
         for m in 1...12 {
             for d in 1...daysInMonth[m - 1] {
                 let day = try SixtyCycleDay(year: 2024, month: m, day: d)
-                let _ = day.getGods()
-                let _ = day.getRecommends()
-                let _ = day.getAvoids()
+                let _ = day.gods
+                let _ = day.recommends
+                let _ = day.avoids
             }
         }
     }


### PR DESCRIPTION
## Summary

- Convert all no-arg `getXxx()` methods in the `culture` module to Swift computed properties (e.g., `getDirection()` → `direction`, `isAuspicious()` → `auspicious`)
- Keep each old getter as a `@available(*, deprecated, renamed:)` wrapper for full backward compatibility
- Fix lingering deprecated calls in `EightChar.swift` and `ChildLimitProvider.swift` (from prior module tasks)
- Update all test files to use the new computed property API

## Files Changed

**Sources (~43 files):**
- `culture/`: Direction, Element, Land, Zone, Beast, Zodiac, Sound, NaYin, Sixty, Phenology, PhenologyDay, Ten, Twenty, TenDay, Terrain, PhaseDay, Animal, PlumRain, Luck, MinorRen, KitchenGodSteed, LifePalace, BodyPalace
- `culture/god/`: God, YearGod, MonthGod, HourGod, DayGod, JoyGod, WealthGod, FortuneGod, YangNobleGod, YinNobleGod
- `culture/taboo/`: Taboo, DayTaboo
- `culture/fetus/`: Fetus, FetusOrigin, FetusDay
- `culture/dog/`, `nine/`, `plumrain/`: DogDay, NineColdDay, PlumRainDay
- `eightchar/EightChar.swift` + `ChildLimitProvider.swift`

**Tests (~5 files):** GodTests, FetusTests, CultureTests, EightCharTests, RegressionTests

## Test plan

- [x] `swift build` — 0 warnings, 0 errors
- [x] `swift test` — 114/114 tests pass with 0 failures

Closes part of #34 (Phase 3b-6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)