### PR TITLE
fix: Resolve try! crash in god direction and RabByungElement

### DIFF
--- a/Sources/tyme/culture/god/FortuneGod.swift
+++ b/Sources/tyme/culture/god/FortuneGod.swift
@@ -23,7 +23,7 @@ public final class FortuneGod: AbstractCulture {
         return FortuneGod.DIRECTIONS[heavenStemIndex]
     }
 
-    public var direction: Direction { try! Direction.fromName(getName()) }
+    public var direction: Direction { try! Direction.fromName(getName().replacingOccurrences(of: "正", with: "")) }
 
     @available(*, deprecated, renamed: "direction")
     public func getDirection() -> Direction { direction }

--- a/Sources/tyme/culture/god/YangNobleGod.swift
+++ b/Sources/tyme/culture/god/YangNobleGod.swift
@@ -23,7 +23,7 @@ public final class YangNobleGod: AbstractCulture {
         return YangNobleGod.DIRECTIONS[heavenStemIndex]
     }
 
-    public var direction: Direction { try! Direction.fromName(getName()) }
+    public var direction: Direction { try! Direction.fromName(getName().replacingOccurrences(of: "正", with: "")) }
 
     @available(*, deprecated, renamed: "direction")
     public func getDirection() -> Direction { direction }

--- a/Sources/tyme/culture/god/YinNobleGod.swift
+++ b/Sources/tyme/culture/god/YinNobleGod.swift
@@ -23,7 +23,7 @@ public final class YinNobleGod: AbstractCulture {
         return YinNobleGod.DIRECTIONS[heavenStemIndex]
     }
 
-    public var direction: Direction { try! Direction.fromName(getName()) }
+    public var direction: Direction { try! Direction.fromName(getName().replacingOccurrences(of: "正", with: "")) }
 
     @available(*, deprecated, renamed: "direction")
     public func getDirection() -> Direction { direction }

--- a/Sources/tyme/tibetan/RabByungElement.swift
+++ b/Sources/tyme/tibetan/RabByungElement.swift
@@ -21,7 +21,7 @@ public final class RabByungElement: AbstractCulture {
     public init(name: String) throws {
         // Convert 铁 to 金 for internal Element
         let elementName = name.replacingOccurrences(of: "铁", with: "金")
-        self.element = try! Element.fromName(elementName)
+        self.element = try Element.fromName(elementName)
         super.init()
     }
 

--- a/Tests/tymeTests/GodTests.swift
+++ b/Tests/tymeTests/GodTests.swift
@@ -183,4 +183,12 @@ import Testing
             #expect(!taboo.getName().isEmpty)
         }
     }
+    @Test func testGodDirectionAllIndices() {
+        for i in 0..<10 {
+            let hs = HeavenStem.fromIndex(i)
+            _ = YangNobleGod.fromHeavenStem(hs).direction
+            _ = YinNobleGod.fromHeavenStem(hs).direction
+            _ = FortuneGod.fromHeavenStem(hs).direction
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- **Issue #60**: `FortuneGod`, `YangNobleGod`, `YinNobleGod` — `direction` computed property used `try! Direction.fromName(getName())` which crashes when `getName()` returns non-standard values like "正西", "正北", "正东", "正南". Fixed by stripping the "正" prefix before lookup.
- **Issue #61**: `RabByungElement` name initializer used `try!` instead of `try`, suppressing proper error propagation.

Closes #60
Closes #61

## Changes

- `FortuneGod.swift`: `direction` now strips "正" prefix before `Direction.fromName` lookup
- `YangNobleGod.swift`: same fix
- `YinNobleGod.swift`: same fix
- `RabByungElement.swift`: line 24 `try! Element.fromName(elementName)` → `try Element.fromName(elementName)`
- `GodTests.swift`: add `testGodDirectionAllIndices` — verifies all 10 `HeavenStem` indices don't crash for `YangNobleGod`, `YinNobleGod`, `FortuneGod`

## Test plan

- [x] `swift test` — 115 tests in 10 suites passed (1 new test added)
- [x] `testGodDirectionAllIndices` explicitly exercises all 10 indices for the 3 affected god types