### PR TITLE
fix: Replace try! with throwing direction property in noble/fortune gods

### DIFF
--- a/Sources/tyme/culture/god/FortuneGod.swift
+++ b/Sources/tyme/culture/god/FortuneGod.swift
@@ -23,10 +23,13 @@ public final class FortuneGod: AbstractCulture {
         return FortuneGod.DIRECTIONS[heavenStemIndex]
     }
 
-    public var direction: Direction { try! Direction.fromName(getName().replacingOccurrences(of: "正", with: "")) }
+    /// The direction derived from this god's position.
+    /// DIRECTIONS values containing "正" prefix (e.g. "正北") are mapped to
+    /// standard Direction.NAMES (e.g. "北") by stripping the prefix.
+    public var direction: Direction { get throws { try Direction.fromName(getName().replacingOccurrences(of: "正", with: "")) } }
 
     @available(*, deprecated, renamed: "direction")
-    public func getDirection() -> Direction { direction }
+    public func getDirection() throws -> Direction { try direction }
 
     /// Create from heaven stem
     /// - Parameter heavenStem: Heaven stem

--- a/Sources/tyme/culture/god/YangNobleGod.swift
+++ b/Sources/tyme/culture/god/YangNobleGod.swift
@@ -23,10 +23,13 @@ public final class YangNobleGod: AbstractCulture {
         return YangNobleGod.DIRECTIONS[heavenStemIndex]
     }
 
-    public var direction: Direction { try! Direction.fromName(getName().replacingOccurrences(of: "正", with: "")) }
+    /// The direction derived from this god's position.
+    /// DIRECTIONS values containing "正" prefix (e.g. "正西") are mapped to
+    /// standard Direction.NAMES (e.g. "西") by stripping the prefix.
+    public var direction: Direction { get throws { try Direction.fromName(getName().replacingOccurrences(of: "正", with: "")) } }
 
     @available(*, deprecated, renamed: "direction")
-    public func getDirection() -> Direction { direction }
+    public func getDirection() throws -> Direction { try direction }
 
     /// Create from heaven stem
     /// - Parameter heavenStem: Heaven stem

--- a/Sources/tyme/culture/god/YinNobleGod.swift
+++ b/Sources/tyme/culture/god/YinNobleGod.swift
@@ -23,10 +23,13 @@ public final class YinNobleGod: AbstractCulture {
         return YinNobleGod.DIRECTIONS[heavenStemIndex]
     }
 
-    public var direction: Direction { try! Direction.fromName(getName().replacingOccurrences(of: "正", with: "")) }
+    /// The direction derived from this god's position.
+    /// DIRECTIONS values containing "正" prefix (e.g. "正西") are mapped to
+    /// standard Direction.NAMES (e.g. "西") by stripping the prefix.
+    public var direction: Direction { get throws { try Direction.fromName(getName().replacingOccurrences(of: "正", with: "")) } }
 
     @available(*, deprecated, renamed: "direction")
-    public func getDirection() -> Direction { direction }
+    public func getDirection() throws -> Direction { try direction }
 
     /// Create from heaven stem
     /// - Parameter heavenStem: Heaven stem

--- a/Tests/tymeTests/GodTests.swift
+++ b/Tests/tymeTests/GodTests.swift
@@ -129,21 +129,21 @@ import Testing
         let heavenStem = HeavenStem.fromIndex(0) // 甲
         let fortuneGod = FortuneGod.fromHeavenStem(heavenStem)
         #expect(fortuneGod.getName() == "东南")
-        _ = fortuneGod.direction
+        _ = try fortuneGod.direction
     }
     @Test func testYangNobleGod() throws {
         // Test yang noble god directions
         let heavenStem = HeavenStem.fromIndex(0) // 甲
         let yangNobleGod = YangNobleGod.fromHeavenStem(heavenStem)
         #expect(yangNobleGod.getName() == "西南")
-        _ = yangNobleGod.direction
+        _ = try yangNobleGod.direction
     }
     @Test func testYinNobleGod() throws {
         // Test yin noble god directions
         let heavenStem = HeavenStem.fromIndex(0) // 甲
         let yinNobleGod = YinNobleGod.fromHeavenStem(heavenStem)
         #expect(yinNobleGod.getName() == "东北")
-        _ = yinNobleGod.direction
+        _ = try yinNobleGod.direction
     }
     @Test func testGodLookup() throws {
         // Test God lookup for a known date (2024-01-01)
@@ -183,12 +183,28 @@ import Testing
             #expect(!taboo.getName().isEmpty)
         }
     }
-    @Test func testGodDirectionAllIndices() {
+    @Test func testGodDirectionAllIndices() throws {
         for i in 0..<10 {
             let hs = HeavenStem.fromIndex(i)
-            _ = YangNobleGod.fromHeavenStem(hs).direction
-            _ = YinNobleGod.fromHeavenStem(hs).direction
-            _ = FortuneGod.fromHeavenStem(hs).direction
+            _ = try YangNobleGod.fromHeavenStem(hs).direction
+            _ = try YinNobleGod.fromHeavenStem(hs).direction
+            _ = try FortuneGod.fromHeavenStem(hs).direction
         }
+
+        // YangNobleGod "正"-prefix indices: 2(正西→西), 5(正北→北), 7(正东→东), 8(正南→南)
+        #expect(try YangNobleGod.fromHeavenStem(HeavenStem.fromIndex(2)).direction.getName() == "西")
+        #expect(try YangNobleGod.fromHeavenStem(HeavenStem.fromIndex(5)).direction.getName() == "北")
+        #expect(try YangNobleGod.fromHeavenStem(HeavenStem.fromIndex(7)).direction.getName() == "东")
+        #expect(try YangNobleGod.fromHeavenStem(HeavenStem.fromIndex(8)).direction.getName() == "南")
+
+        // YinNobleGod "正"-prefix indices: 3(正西→西), 4(正北→北), 6(正东→东), 9(正南→南)
+        #expect(try YinNobleGod.fromHeavenStem(HeavenStem.fromIndex(3)).direction.getName() == "西")
+        #expect(try YinNobleGod.fromHeavenStem(HeavenStem.fromIndex(4)).direction.getName() == "北")
+        #expect(try YinNobleGod.fromHeavenStem(HeavenStem.fromIndex(6)).direction.getName() == "东")
+        #expect(try YinNobleGod.fromHeavenStem(HeavenStem.fromIndex(9)).direction.getName() == "南")
+
+        // FortuneGod "正"-prefix indices: 2(正北→北), 7(正北→北)
+        #expect(try FortuneGod.fromHeavenStem(HeavenStem.fromIndex(2)).direction.getName() == "北")
+        #expect(try FortuneGod.fromHeavenStem(HeavenStem.fromIndex(7)).direction.getName() == "北")
     }
 }


### PR DESCRIPTION
## Summary

- **Issue #66**: Convert `direction: Direction { try! ... }` to `direction: Direction { get throws { try ... } }` in FortuneGod, YangNobleGod, YinNobleGod. Update deprecated `getDirection()` to `throws`. Consistent with Issue #32 project direction (fatalError → throws).
- **Issue #65**: Add invariant comment to `direction` property explaining "正" prefix stripping (e.g. "正西" → "西").
- **Issue #64**: Add value assertions in `testGodDirectionAllIndices` for all "正"-prefix indices (YangNobleGod: 2/5/7/8, YinNobleGod: 3/4/6/9, FortuneGod: 2/7). Update smoke test loop to use `try`.

**Files changed:**
- `Sources/tyme/culture/god/FortuneGod.swift`
- `Sources/tyme/culture/god/YangNobleGod.swift`
- `Sources/tyme/culture/god/YinNobleGod.swift`
- `Tests/tymeTests/GodTests.swift`

## Test plan

- [x] `swift build` passes (0 warnings)
- [x] `swift test` passes: 115 tests in 10 suites, 0 failures

Closes #64, Closes #65, Closes #66