### PR TITLE
fix: resolve Swift tools version mismatch in macOS CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Swift
-        if: runner.os == 'Linux'
         uses: swift-actions/setup-swift@v2
         with:
           swift-version: '6.2'


### PR DESCRIPTION
Fixes CI error: package using Swift tools version 6.2.0 but macOS runner has 6.1.0

## Problem

The macOS CI runner uses Xcode's bundled Swift (6.1), but `Package.swift` declares `swift-tools-version: 6.2`. The `Setup Swift` step only ran on Linux, so macOS used the system Swift 6.1 and failed.

## Fix

Remove the `if: runner.os == 'Linux'` condition from the `Setup Swift` step so `swift-actions/setup-swift@v2` installs Swift 6.2 on **both** Linux and macOS runners. This ensures consistent Swift versions across all platforms.

## Alternatives Considered

- **Downgrade tools version to 6.1**: Rejected — the project explicitly targets Swift 6.2, and downgrading risks losing language guarantees even though the simple Package.swift manifest itself doesn't use 6.2-specific features.

Part of #34