### PR TITLE
feat: Add Codable support for 5 core types (Phase 3c-1)

### DIFF
--- a/Sources/tyme/eightchar/EightChar.swift
+++ b/Sources/tyme/eightchar/EightChar.swift
@@ -126,3 +126,27 @@ public final class EightChar {
         return solarMonth
     }
 }
+
+extension EightChar: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case solarYear, solarMonth, solarDay, solarHour
+    }
+
+    public convenience init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            year: try container.decode(Int.self, forKey: .solarYear),
+            month: try container.decode(Int.self, forKey: .solarMonth),
+            day: try container.decode(Int.self, forKey: .solarDay),
+            hour: try container.decode(Int.self, forKey: .solarHour)
+        )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(solarYear, forKey: .solarYear)
+        try container.encode(solarMonth, forKey: .solarMonth)
+        try container.encode(solarDay, forKey: .solarDay)
+        try container.encode(solarHour, forKey: .solarHour)
+    }
+}

--- a/Sources/tyme/lunar/LunarDay.swift
+++ b/Sources/tyme/lunar/LunarDay.swift
@@ -73,3 +73,24 @@ public final class LunarDay: DayUnit, Tyme {
     @available(*, deprecated, renamed: "fetusDay")
     public func getFetusDay() -> FetusDay { fetusDay }
 }
+
+extension LunarDay: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case year, month, day
+    }
+
+    public convenience init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let year = try container.decode(Int.self, forKey: .year)
+        let month = try container.decode(Int.self, forKey: .month)
+        let day = try container.decode(Int.self, forKey: .day)
+        try self.init(year: year, month: month, day: day)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(year, forKey: .year)
+        try container.encode(monthWithLeap, forKey: .month)
+        try container.encode(day, forKey: .day)
+    }
+}

--- a/Sources/tyme/sixtycycle/SixtyCycle.swift
+++ b/Sources/tyme/sixtycycle/SixtyCycle.swift
@@ -31,3 +31,20 @@ public final class SixtyCycle: LoopTyme {
     @available(*, deprecated, renamed: "earthBranch")
     public func getEarthBranch() -> EarthBranch { earthBranch }
 }
+
+extension SixtyCycle: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case index
+    }
+
+    public convenience init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let index = try container.decode(Int.self, forKey: .index)
+        self.init(index: index)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(index, forKey: .index)
+    }
+}

--- a/Sources/tyme/solar/SolarDay.swift
+++ b/Sources/tyme/solar/SolarDay.swift
@@ -101,3 +101,24 @@ public final class SolarDay: DayUnit, Tyme {
     @available(*, deprecated, renamed: "lunarDay")
     public func getLunarDay() -> LunarDay { lunarDay }
 }
+
+extension SolarDay: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case year, month, day
+    }
+
+    public convenience init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let year = try container.decode(Int.self, forKey: .year)
+        let month = try container.decode(Int.self, forKey: .month)
+        let day = try container.decode(Int.self, forKey: .day)
+        try self.init(year: year, month: month, day: day)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(year, forKey: .year)
+        try container.encode(month, forKey: .month)
+        try container.encode(day, forKey: .day)
+    }
+}

--- a/Sources/tyme/solar/SolarTime.swift
+++ b/Sources/tyme/solar/SolarTime.swift
@@ -86,3 +86,31 @@ public final class SolarTime: SecondUnit, Tyme {
     @available(*, deprecated, renamed: "term")
     public func getTerm() -> SolarTerm { term }
 }
+
+extension SolarTime: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case year, month, day, hour, minute, second
+    }
+
+    public convenience init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        try self.init(
+            year: container.decode(Int.self, forKey: .year),
+            month: container.decode(Int.self, forKey: .month),
+            day: container.decode(Int.self, forKey: .day),
+            hour: container.decode(Int.self, forKey: .hour),
+            minute: container.decode(Int.self, forKey: .minute),
+            second: container.decode(Int.self, forKey: .second)
+        )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(year, forKey: .year)
+        try container.encode(month, forKey: .month)
+        try container.encode(day, forKey: .day)
+        try container.encode(hour, forKey: .hour)
+        try container.encode(minute, forKey: .minute)
+        try container.encode(second, forKey: .second)
+    }
+}

--- a/Tests/tymeTests/CodableTests.swift
+++ b/Tests/tymeTests/CodableTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import Testing
+@testable import tyme
+
+@Suite struct CodableTests {
+
+    // MARK: - SolarDay
+
+    @Test func testSolarDayCodableRoundTrip() throws {
+        let original = try SolarDay.fromYmd(2024, 1, 15)
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(SolarDay.self, from: data)
+        #expect(decoded.year == original.year)
+        #expect(decoded.month == original.month)
+        #expect(decoded.day == original.day)
+    }
+
+    @Test func testSolarDayCodableLeapYear() throws {
+        let original = try SolarDay.fromYmd(2024, 2, 29)
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(SolarDay.self, from: data)
+        #expect(decoded.year == 2024)
+        #expect(decoded.month == 2)
+        #expect(decoded.day == 29)
+    }
+
+    // MARK: - LunarDay
+
+    @Test func testLunarDayCodableRoundTrip() throws {
+        let original = try LunarDay(year: 2024, month: 1, day: 15)
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(LunarDay.self, from: data)
+        #expect(decoded.year == original.year)
+        #expect(decoded.month == original.month)
+        #expect(decoded.day == original.day)
+    }
+
+    @Test func testLunarDayCodableLeapMonth() throws {
+        // 2023 has leap month 2
+        let original = try LunarDay(year: 2023, month: -2, day: 15)
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(LunarDay.self, from: data)
+        #expect(decoded.year == original.year)
+        #expect(decoded.monthWithLeap == original.monthWithLeap) // negative = leap
+        #expect(decoded.day == original.day)
+        #expect(decoded.monthWithLeap < 0)
+    }
+
+    // MARK: - SolarTime
+
+    @Test func testSolarTimeCodableRoundTrip() throws {
+        let original = try SolarTime(year: 2024, month: 6, day: 15, hour: 12, minute: 30, second: 45)
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(SolarTime.self, from: data)
+        #expect(decoded.year == original.year)
+        #expect(decoded.month == original.month)
+        #expect(decoded.day == original.day)
+        #expect(decoded.hour == original.hour)
+        #expect(decoded.minute == original.minute)
+        #expect(decoded.second == original.second)
+    }
+
+    @Test func testSolarTimeCodableMidnight() throws {
+        let original = try SolarTime(year: 2024, month: 1, day: 1, hour: 0, minute: 0, second: 0)
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(SolarTime.self, from: data)
+        #expect(decoded.year == 2024)
+        #expect(decoded.month == 1)
+        #expect(decoded.day == 1)
+        #expect(decoded.hour == 0)
+        #expect(decoded.minute == 0)
+        #expect(decoded.second == 0)
+    }
+
+    // MARK: - EightChar
+
+    @Test func testEightCharCodableRoundTrip() throws {
+        let original = EightChar(year: 2024, month: 1, day: 15, hour: 12)
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(EightChar.self, from: data)
+        #expect(decoded.solarYear == original.solarYear)
+        #expect(decoded.solarMonth == original.solarMonth)
+        #expect(decoded.solarDay == original.solarDay)
+        #expect(decoded.solarHour == original.solarHour)
+        // Verify pillars are reconstructed correctly
+        #expect(decoded.getEightCharString() == original.getEightCharString())
+    }
+
+    @Test func testEightCharCodableJsonShape() throws {
+        let ec = EightChar(year: 2024, month: 1, day: 1, hour: 0)
+        let data = try JSONEncoder().encode(ec)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Int]
+        #expect(json?["solarYear"] == 2024)
+        #expect(json?["solarMonth"] == 1)
+        #expect(json?["solarDay"] == 1)
+        #expect(json?["solarHour"] == 0)
+    }
+
+    // MARK: - SixtyCycle
+
+    @Test func testSixtyCycleCodableRoundTrip() throws {
+        let original = SixtyCycle.fromIndex(0) // 甲子
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(SixtyCycle.self, from: data)
+        #expect(decoded.index == original.index)
+        #expect(decoded.getName() == original.getName())
+    }
+
+    @Test func testSixtyCycleCodableAllIndices() throws {
+        for i in 0..<60 {
+            let original = SixtyCycle.fromIndex(i)
+            let data = try JSONEncoder().encode(original)
+            let decoded = try JSONDecoder().decode(SixtyCycle.self, from: data)
+            #expect(decoded.index == i)
+            #expect(decoded.getName() == original.getName())
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add `Codable` conformance to 5 core types via extensions, using minimal encoding that reconstructs objects through existing validated factory methods.

| Type | Encoded keys | Decode via |
|------|-------------|------------|
| `SolarDay` | `year`, `month`, `day` | `init(year:month:day:)` |
| `LunarDay` | `year`, `month` (negative=leap), `day` | `init(year:month:day:)` |
| `SolarTime` | `year`, `month`, `day`, `hour`, `minute`, `second` | `init(year:month:day:hour:minute:second:)` |
| `EightChar` | `solarYear`, `solarMonth`, `solarDay`, `solarHour` | `init(year:month:day:hour:)` |
| `SixtyCycle` | `index` | `convenience init(index:)` |

**Design decisions:**
- Extensions added at bottom of each type's `.swift` file (no new files)
- `convenience init(from:)` works in extensions since all 5 types are `public final class`
- Decode routes through existing validated inits to preserve validation logic
- LunarDay encodes `monthWithLeap` (negative = leap month) to preserve leap month info

## Test plan

- [x] `swift build` passes (0 errors)
- [x] `swift test` passes: 125 tests in 11 suites, 0 failures
- [x] New `CodableTests.swift`: 10 tests covering round-trip and boundary cases (leap year 2/29, leap lunar month)

Part of #34