### PR TITLE
docs: Add DocC documentation and swift-docc-plugin (Phase 3c-2)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "14ceed0aa437779ed3342f5b2a44988901e18a26874cf4137676fc0f2b19102f",
+  "pins" : [
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-plugin",
+      "state" : {
+        "revision" : "e977f65879f82b375a044c8837597f690c067da6",
+        "version" : "1.4.6"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,9 @@ let package = Package(
             targets: ["tyme"]
         ),
     ],
+    dependencies: [
+        .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.4.3"),
+    ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         // Targets can depend on other targets in this package and products from dependencies.

--- a/Sources/tyme/lunar/LunarDay.swift
+++ b/Sources/tyme/lunar/LunarDay.swift
@@ -1,8 +1,21 @@
 import Foundation
 
+/// A day in the Chinese lunar calendar (农历 Nónglì).
+///
+/// `LunarDay` represents a specific date in the traditional Chinese lunisolar calendar.
+/// Lunar months can be regular or leap (闰月 Rùnyuè), indicated by a negative month value.
+///
+/// ## Usage
+///
+/// ```swift
+/// let day = try LunarDay(year: 2024, month: 1, day: 15)   // Regular month
+/// let leap = try LunarDay(year: 2023, month: -2, day: 15)  // Leap month 2
+/// let solarDay = day.solarDay                               // Convert to solar
+/// ```
 public final class LunarDay: DayUnit, Tyme {
     public static let NAMES = ["初一", "初二", "初三", "初四", "初五", "初六", "初七", "初八", "初九", "初十", "十一", "十二", "十三", "十四", "十五", "十六", "十七", "十八", "十九", "二十", "廿一", "廿二", "廿三", "廿四", "廿五", "廿六", "廿七", "廿八", "廿九", "三十"]
 
+    /// Whether this day falls in a leap month (闰月 Rùnyuè).
     public let leap: Bool
 
     public static func validate(year: Int, month: Int, day: Int) throws {
@@ -17,7 +30,7 @@ public final class LunarDay: DayUnit, Tyme {
         try super.init(year: year, month: abs(month), day: day)
     }
 
-    /// Returns signed month (negative if leap month)
+    /// The month number, negative if leap month. E.g., -4 means leap month 4.
     public var monthWithLeap: Int { leap ? -month : month }
 
     public static func fromYmd(_ year: Int, _ month: Int, _ day: Int) throws -> LunarDay {
@@ -43,12 +56,14 @@ public final class LunarDay: DayUnit, Tyme {
     }
 
     public var week: Week { solarDay.week }
+    /// The sexagenary cycle for this lunar day (日干支 Rì Gānzhī).
     public var sixtyCycle: SixtyCycle {
         let offset = Int(lunarMonth.firstJulianDay.next(day - 12).value)
         let stem = HeavenStem.fromIndex(offset).getName()
         let branch = EarthBranch.fromIndex(offset).getName()
         return try! SixtyCycle.fromName(stem + branch)
     }
+    /// The corresponding Gregorian calendar date.
     public var solarDay: SolarDay {
         lunarMonth.firstJulianDay.next(day - 1).solarDay
     }

--- a/Sources/tyme/sixtycycle/EarthBranch.swift
+++ b/Sources/tyme/sixtycycle/EarthBranch.swift
@@ -1,5 +1,26 @@
 import Foundation
 
+/// An Earthly Branch (地支 Dìzhī) in the Chinese sexagenary cycle.
+///
+/// The 12 Earthly Branches form the other component of the sexagenary cycle.
+/// Each branch is associated with a Chinese zodiac animal (生肖 Shēngxiào),
+/// a Yin-Yang polarity, and one of the Five Elements.
+///
+/// ## The 12 Branches (partial)
+///
+/// | Index | Name | Zodiac | Element |
+/// |-------|------|--------|---------|
+/// | 0 | 子 (Zǐ) | 鼠 Rat | 水 Water |
+/// | 1 | 丑 (Chǒu) | 牛 Ox | 土 Earth |
+/// | ... | ... | ... | ... |
+///
+/// ## Usage
+///
+/// ```swift
+/// let branch = EarthBranch.fromIndex(0)  // 子
+/// let zodiac = branch.zodiac             // 鼠 (Rat)
+/// let stems = branch.hideHeavenStems     // Hidden stems (藏干 Cánggān)
+/// ```
 public final class EarthBranch: LoopTyme {
     public static let NAMES = ["子","丑","寅","卯","辰","巳","午","未","申","酉","戌","亥"]
 
@@ -57,6 +78,7 @@ public final class EarthBranch: LoopTyme {
         EarthBranch.fromIndex(nextIndex(n))
     }
 
+    /// The Chinese zodiac animal (生肖 Shēngxiào) for this branch.
     public var zodiac: String { EarthBranch.ZODIAC_NAMES[index] }
     public var yinYang: String { EarthBranch.YIN_YANG[index] }
     public var wuXing: String { EarthBranch.WU_XING[index] }
@@ -106,6 +128,7 @@ extension EarthBranch {
     ]
 
     /// Get hidden heaven stems
+    /// The hidden Heavenly Stems (藏干 Cánggān) within this branch.
     public var hideHeavenStems: [HideHeavenStem] {
         var result: [HideHeavenStem] = []
         let stems = EarthBranch.HIDE_STEMS[index]
@@ -121,7 +144,7 @@ extension EarthBranch {
         return result
     }
 
-    /// Get main hidden heaven stem (本气)
+    /// The main hidden stem (本气 Běnqì) of this branch.
     public var mainHideHeavenStem: HeavenStem? {
         if let mainIndex = EarthBranch.HIDE_STEMS[index][0] {
             return HeavenStem.fromIndex(mainIndex)

--- a/Sources/tyme/sixtycycle/HeavenStem.swift
+++ b/Sources/tyme/sixtycycle/HeavenStem.swift
@@ -1,5 +1,26 @@
 import Foundation
 
+/// A Heavenly Stem (天干 Tiāngān) in the Chinese sexagenary cycle.
+///
+/// The 10 Heavenly Stems form one component of the sexagenary cycle (六十甲子 Liùshí Jiǎzǐ).
+/// Each stem is associated with a Yin-Yang polarity (阴阳 Yīnyáng) and
+/// one of the Five Elements (五行 Wǔxíng).
+///
+/// ## The 10 Stems (partial)
+///
+/// | Index | Name | Element | Yin/Yang |
+/// |-------|------|---------|----------|
+/// | 0 | 甲 (Jiǎ) | 木 Wood | Yang |
+/// | 1 | 乙 (Yǐ) | 木 Wood | Yin |
+/// | ... | ... | ... | ... |
+///
+/// ## Usage
+///
+/// ```swift
+/// let stem = HeavenStem.fromIndex(0)  // 甲
+/// let element = stem.wuXing           // 木 (Wood)
+/// let yinYang = stem.yinYang          // 阳 (Yang)
+/// ```
 public final class HeavenStem: LoopTyme {
     public static let NAMES = ["甲","乙","丙","丁","戊","己","庚","辛","壬","癸"]
 

--- a/Sources/tyme/sixtycycle/SixtyCycle.swift
+++ b/Sources/tyme/sixtycycle/SixtyCycle.swift
@@ -1,5 +1,18 @@
 import Foundation
 
+/// A sexagenary cycle element (六十甲子 Liùshí Jiǎzǐ).
+///
+/// The sexagenary cycle combines the 10 Heavenly Stems (天干 Tiāngān) and
+/// 12 Earthly Branches (地支 Dìzhī) to form a 60-element cycle used
+/// extensively in Chinese calendrical and metaphysical systems.
+///
+/// ## Usage
+///
+/// ```swift
+/// let cycle = SixtyCycle.fromIndex(0)      // 甲子
+/// let stem = cycle.heavenStem              // 甲
+/// let branch = cycle.earthBranch           // 子
+/// ```
 public final class SixtyCycle: LoopTyme {
     public static let NAMES = ["甲子", "乙丑", "丙寅", "丁卯", "戊辰", "己巳", "庚午", "辛未", "壬申", "癸酉", "甲戌", "乙亥", "丙子", "丁丑", "戊寅", "己卯", "庚辰", "辛巳", "壬午", "癸未", "甲申", "乙酉", "丙戌", "丁亥", "戊子", "己丑", "庚寅", "辛卯", "壬辰", "癸巳", "甲午", "乙未", "丙申", "丁酉", "戊戌", "己亥", "庚子", "辛丑", "壬寅", "癸卯", "甲辰", "乙巳", "丙午", "丁未", "戊申", "己酉", "庚戌", "辛亥", "壬子", "癸丑", "甲寅", "乙卯", "丙辰", "丁巳", "戊午", "己未", "庚申", "辛酉", "壬戌", "癸亥"]
 

--- a/Sources/tyme/solar/SolarDay.swift
+++ b/Sources/tyme/solar/SolarDay.swift
@@ -1,5 +1,33 @@
 import Foundation
 
+/// A day in the Gregorian (solar) calendar.
+///
+/// `SolarDay` represents a specific date in the solar calendar system,
+/// providing conversions to the lunar calendar, sexagenary cycle, and solar terms.
+///
+/// ## Usage
+///
+/// ```swift
+/// let day = try SolarDay.fromYmd(2024, 1, 15)
+/// let lunarDay = day.lunarDay        // Convert to lunar calendar
+/// let cycle = day.sixtyCycleDay      // Get sexagenary cycle day
+/// let term = day.term                // Get solar term
+/// ```
+///
+/// ## Topics
+///
+/// ### Creating a Solar Day
+/// - ``fromYmd(_:_:_:)``
+/// - ``init(year:month:day:)``
+///
+/// ### Calendar Conversions
+/// - ``lunarDay``
+/// - ``julianDay``
+/// - ``sixtyCycleDay``
+///
+/// ### Solar Terms
+/// - ``term``
+/// - ``termDay``
 public final class SolarDay: DayUnit, Tyme {
     public override init(year: Int, month: Int, day: Int) throws {
         try SolarUtil.validateYear(year)
@@ -7,16 +35,20 @@ public final class SolarDay: DayUnit, Tyme {
         try super.init(year: year, month: month, day: day)
     }
 
+    /// Creates a solar day from year, month, and day components.
+    /// - Throws: `TymeError` if the date is invalid.
     public static func fromYmd(_ year: Int, _ month: Int, _ day: Int) throws -> SolarDay {
         try SolarDay(year: year, month: month, day: day)
     }
 
     public func getName() -> String { String(format: "%04d-%02d-%02d", year, month, day) }
 
+    /// The Julian Day number for astronomical calculations.
     public var julianDay: JulianDay { try! JulianDay.fromYmdHms(year: year, month: month, day: day) }
     public var solarMonth: SolarMonth { try! SolarMonth(year: year, month: month) }
     public var solarYear: SolarYear { try! SolarYear(year: year) }
     public var week: Week { julianDay.week }
+    /// The solar term day (节气日 Jiéqì Rì) for this date.
     public var termDay: SolarTermDay {
         var y = year
         var i = month * 2
@@ -32,8 +64,11 @@ public final class SolarDay: DayUnit, Tyme {
         }
         return SolarTermDay(term, subtract(td))
     }
+    /// The solar term (节气 Jiéqì) at this date.
     public var term: SolarTerm { termDay.solarTerm }
+    /// The sexagenary cycle day (六十甲子日 Liùshí Jiǎzǐ Rì).
     public var sixtyCycleDay: SixtyCycleDay { SixtyCycleDay(solarDay: self) }
+    /// The corresponding day in the Chinese lunar calendar (农历 Nónglì).
     public var lunarDay: LunarDay {
         var m = try! LunarMonth.fromYm(year, month)
         var days = subtract(m.firstJulianDay.solarDay)
@@ -48,6 +83,8 @@ public final class SolarDay: DayUnit, Tyme {
         return try! LunarDay.fromYmd(m.year, m.monthWithLeap, days + 1)
     }
 
+    /// Returns the solar day offset by the given number of days.
+    /// - Parameter n: Positive to advance, negative to go back.
     public func next(_ n: Int) -> SolarDay {
         let jd = julianDay
         let target = JulianDay(jd.value + Double(n))

--- a/Sources/tyme/solar/SolarTerm.swift
+++ b/Sources/tyme/solar/SolarTerm.swift
@@ -1,5 +1,26 @@
 import Foundation
 
+/// A solar term (节气 Jiéqì) in the Chinese calendar.
+///
+/// The 24 solar terms divide the tropical year into 24 segments based on
+/// the Sun's ecliptic longitude. They alternate between minor terms (节 Jié)
+/// and major terms (中气 Zhōngqì).
+///
+/// ## The 24 Solar Terms (partial)
+///
+/// | Index | Name | Pinyin |
+/// |-------|------|--------|
+/// | 0 | 冬至 | Dōngzhì (Winter Solstice) |
+/// | 1 | 小寒 | Xiǎohán (Minor Cold) |
+/// | 2 | 大寒 | Dàhán (Major Cold) |
+/// | ... | ... | ... |
+///
+/// ## Usage
+///
+/// ```swift
+/// let term = try SolarTerm(year: 2024, name: "春分")
+/// let day = term.solarDay  // The day this term begins
+/// ```
 public final class SolarTerm: LoopTyme {
     public static let NAMES = ["冬至", "小寒", "大寒", "立春", "雨水", "惊蛰", "春分", "清明", "谷雨", "立夏", "小满", "芒种", "夏至", "小暑", "大暑", "立秋", "处暑", "白露", "秋分", "寒露", "霜降", "立冬", "小雪", "大雪"]
 
@@ -51,13 +72,17 @@ public final class SolarTerm: LoopTyme {
         return try! SolarTerm(year: (year * size + i) / size, index: ((i % size) + size) % size)
     }
 
+    /// Returns `true` if this is a minor term (节 Jié, odd-indexed).
     public func isJie() -> Bool { index % 2 == 1 }
+    /// Returns `true` if this is a major term (中气 Zhōngqì, even-indexed).
     public func isQi() -> Bool { index % 2 == 0 }
 
+    /// The precise Julian Day when this solar term occurs.
     public var julianDay: JulianDay {
         JulianDay.fromJulianDay(ShouXingUtil.qiAccurate2(cursoryJulianDay) + JulianDay.J2000)
     }
 
+    /// The Gregorian calendar date of this solar term.
     public var solarDay: SolarDay {
         JulianDay.fromJulianDay(cursoryJulianDay + JulianDay.J2000).solarDay
     }


### PR DESCRIPTION
## Summary

- Add `swift-docc-plugin` dependency to `Package.swift` for documentation generation
- Add DocC-style documentation comments to 6 core types (pure doc changes, no logic modifications)

**Files documented:** SolarDay, LunarDay, SolarTerm, HeavenStem, EarthBranch, SixtyCycle

## Test plan

- [x] `swift build` passes (0 errors)
- [x] `swift test` passes: 125 tests in 11 suites, 0 failures
- [x] `swift-docc-plugin` dependency resolved successfully

Part of #34