### PR TITLE
ci: add DocC GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
+      - uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: '6.2'
       - name: Build DocC
         run: |
           swift package --allow-writing-to-directory ./docs \


### PR DESCRIPTION
Part of #34 — adds automatic DocC deployment to GitHub Pages on push to main

## Changes

Adds `.github/workflows/docs.yml` that:
- Triggers on push to `main` and `workflow_dispatch`
- Builds DocC documentation with `swift package generate-documentation` using `swift-docc-plugin`
- Transforms output for static hosting with `--hosting-base-path tyme4swift`
- Deploys to GitHub Pages via `actions/deploy-pages@v4`

## Setup Required

GitHub Pages must be enabled in repository **Settings → Pages → Source: GitHub Actions** before the workflow can deploy.

## Notes

- Uses `macos-latest` runner (DocC generation requires macOS/Xcode toolchain)
- `concurrency` group `pages` ensures only one deployment runs at a time
- Permissions scoped to minimum required (`pages: write`, `id-token: write`)