### PR TITLE
ci: integrate SwiftLint with configuration and CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,19 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    name: SwiftLint
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install SwiftLint
+        run: brew install swiftlint
+
+      - name: Run SwiftLint
+        run: swiftlint lint Sources
+
   build-and-test:
     name: Build and Test
     runs-on: ${{ matrix.os }}

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,60 @@
+# SwiftLint Configuration for tyme4swift
+
+excluded:
+  - .build
+  - Benchmarks
+  - Package.swift
+
+# Rule customization
+identifier_name:
+  min_length:
+    warning: 1      # Allow single-char vars (n, i, v, m) common in math/algorithm code
+  max_length:
+    warning: 60
+  excluded:
+    - id
+  allowed_symbols:
+    - _
+  validates_start_with_lowercase: warning
+
+line_length:
+  warning: 150
+  error: 200
+  ignores_urls: true
+  ignores_comments: true
+
+file_length:
+  warning: 600
+  error: 1000
+
+type_body_length:
+  warning: 400
+  error: 600
+
+function_body_length:
+  warning: 60
+  error: 100
+
+function_parameter_count:
+  warning: 6
+  error: 8
+
+large_tuple:
+  warning: 4
+
+# Disabled rules
+disabled_rules:
+  - comma                   # Data tables use aligned spacing (e.g., ShouXingUtil)
+  - trailing_comma          # Optional trailing commas are acceptable
+  - todo                    # TODOs are valid during development
+  - orphaned_doc_comment    # Some legacy doc comments exist
+
+# Opt-in rules
+opt_in_rules:
+  - empty_count             # Prefer .isEmpty over .count == 0
+  - closure_spacing         # Consistent closure formatting
+  - operator_usage_whitespace
+
+# Rule severity overrides
+force_try: warning          # Project has legitimate force-try in safe contexts
+force_cast: warning         # Occasional safe force casts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ swift test --filter SolarTests/testSolarDay   # Run a single test
 swift run -c release TymeBenchmarks           # Run performance benchmarks
 ```
 
-No linter or formatter is configured. Dependencies: swift-docc-plugin (documentation), google/swift-benchmark (benchmarks).
+SwiftLint configured (`.swiftlint.yml`). Run `swiftlint lint Sources` before committing. Dependencies: swift-docc-plugin (documentation), google/swift-benchmark (benchmarks).
 
 ## CI/CD
 


### PR DESCRIPTION
## Summary

- Add `.swiftlint.yml` tailored to existing code style (0 error, 224 warnings)
- Add independent `lint` job in `ci.yml` (macOS, parallel with build-and-test)
- Update `CONTRIBUTING.md` with SwiftLint instructions and full coding standards (API design, Swift Testing, DocC, Codable)
- Update `CLAUDE.md` to reflect linter configuration

## Details

### SwiftLint Configuration

Rules customized to match existing codebase patterns:
- `identifier_name`: allows single-char vars (`n`, `i`, `v`) and UPPER_SNAKE_CASE constants
- `line_length`: warning at 150, error at 200
- `force_try` / `force_cast`: warning only (project has legitimate uses)
- Disabled: `comma` (data table alignment), `trailing_comma`, `todo`, `orphaned_doc_comment`

### CI Integration

New independent `lint` job runs on `macos-latest` in parallel with existing `build-and-test` matrix. Uses `brew install swiftlint`.

## Test plan

- [x] `swiftlint lint Sources` — 0 errors
- [x] `swift build` — passes
- [x] `swift test` — 125 tests pass