### PR TITLE
refactor: add size/stepsTo to LoopTyme base and simplify Dipper to 9 stars

### DIFF
--- a/Sources/tyme/core/LoopTyme.swift
+++ b/Sources/tyme/core/LoopTyme.swift
@@ -23,6 +23,17 @@ open class LoopTyme: AbstractTyme {
     @available(*, deprecated, renamed: "index")
     public func getIndex() -> Int { index }
 
+    /// 循环长度
+    public var size: Int { names.count }
+
+    /// 到目标索引的步数
+    public func stepsTo(_ targetIndex: Int) -> Int {
+        let c = names.count
+        var i = (targetIndex - index) % c
+        if i < 0 { i += c }
+        return i
+    }
+
     public func nextIndex(_ n: Int) -> Int {
         let c = names.count
         var i = (index + n) % c

--- a/Sources/tyme/culture/Direction.swift
+++ b/Sources/tyme/culture/Direction.swift
@@ -23,13 +23,6 @@ public final class Direction: LoopTyme {
         try Direction(name: name)
     }
 
-    public func stepsTo(_ targetIndex: Int) -> Int {
-        let c = Direction.NAMES.count
-        var i = (targetIndex - index) % c
-        if i < 0 { i += c }
-        return i
-    }
-
     public override func next(_ n: Int) -> Direction {
         Direction.fromIndex(nextIndex(n))
     }

--- a/Sources/tyme/culture/Element.swift
+++ b/Sources/tyme/culture/Element.swift
@@ -26,13 +26,6 @@ public final class Element: LoopTyme {
         try Element(name: name)
     }
 
-    public func stepsTo(_ targetIndex: Int) -> Int {
-        let c = Element.NAMES.count
-        var i = (targetIndex - index) % c
-        if i < 0 { i += c }
-        return i
-    }
-
     public override func next(_ n: Int) -> Element {
         Element.fromIndex(nextIndex(n))
     }

--- a/Sources/tyme/sixtycycle/EarthBranch.swift
+++ b/Sources/tyme/sixtycycle/EarthBranch.swift
@@ -67,13 +67,6 @@ public final class EarthBranch: LoopTyme {
         try EarthBranch(name: name)
     }
 
-    public func stepsTo(_ targetIndex: Int) -> Int {
-        let c = EarthBranch.NAMES.count
-        var i = (targetIndex - index) % c
-        if i < 0 { i += c }
-        return i
-    }
-
     public override func next(_ n: Int) -> EarthBranch {
         EarthBranch.fromIndex(nextIndex(n))
     }

--- a/Sources/tyme/sixtycycle/HeavenStem.swift
+++ b/Sources/tyme/sixtycycle/HeavenStem.swift
@@ -64,13 +64,6 @@ public final class HeavenStem: LoopTyme {
         try HeavenStem(name: name)
     }
 
-    public func stepsTo(_ targetIndex: Int) -> Int {
-        let c = HeavenStem.NAMES.count
-        var i = (targetIndex - index) % c
-        if i < 0 { i += c }
-        return i
-    }
-
     public override func next(_ n: Int) -> HeavenStem {
         HeavenStem.fromIndex(nextIndex(n))
     }

--- a/Sources/tyme/star/Dipper.swift
+++ b/Sources/tyme/star/Dipper.swift
@@ -1,107 +1,30 @@
 import Foundation
 
-/// 北斗七星 (Big Dipper / Seven Stars of the Northern Dipper)
-/// 北斗七星是北半球天空中最显著的星座之一
-/// Stars: 天枢, 天璇, 天玑, 天权, 玉衡, 开阳, 摇光
+/// 北斗九星
 public final class Dipper: LoopTyme {
-    /// Star names (北斗七星名称)
-    public static let NAMES = ["天枢", "天璇", "天玑", "天权", "玉衡", "开阳", "摇光"]
+    public static let NAMES = ["天枢", "天璇", "天玑", "天权", "玉衡", "开阳", "摇光", "洞明", "隐元"]
 
-    /// Alternative names (别名)
-    public static let ALTERNATIVE_NAMES = ["贪狼", "巨门", "禄存", "文曲", "廉贞", "武曲", "破军"]
-
-    /// Western names (西方名称)
-    public static let WESTERN_NAMES = ["Dubhe", "Merak", "Phecda", "Megrez", "Alioth", "Mizar", "Alkaid"]
-
-    /// Position descriptions (位置描述)
-    /// 斗魁: 天枢、天璇、天玑、天权 (勺部)
-    /// 斗柄: 玉衡、开阳、摇光 (柄部)
-    private static let POSITIONS = ["斗魁", "斗魁", "斗魁", "斗魁", "斗柄", "斗柄", "斗柄"]
-
-    /// Brightness ranking (亮度排名, 1=最亮)
-    private static let BRIGHTNESS_RANK = [4, 5, 6, 7, 1, 2, 3]
-
-    /// Initialize with index
-    /// - Parameter index: Star index (0-6)
     public convenience init(index: Int) {
         self.init(names: Dipper.NAMES, index: index)
     }
 
-    /// Initialize with name
-    /// - Parameter name: Star name (e.g., "天枢", "天璇", etc.)
     public convenience init(name: String) throws {
         try self.init(names: Dipper.NAMES, name: name)
     }
 
-    /// Required initializer from LoopTyme
     public required init(names: [String], index: Int) {
         super.init(names: names, index: index)
     }
 
-    /// Get Dipper star from index
-    /// - Parameter index: Star index (0-6)
-    /// - Returns: Dipper instance
     public static func fromIndex(_ index: Int) -> Dipper {
-        return Dipper(index: index)
+        Dipper(index: index)
     }
 
-    /// Get Dipper star from name
-    /// - Parameter name: Star name (e.g., "天枢", "天璇", etc.)
-    /// - Returns: Dipper instance
     public static func fromName(_ name: String) throws -> Dipper {
-        return try Dipper(name: name)
+        try Dipper(name: name)
     }
 
-    /// Get Dipper star from alternative name
-    /// - Parameter alternativeName: Alternative name (e.g., "贪狼", "巨门", etc.)
-    /// - Returns: Dipper instance
-    public static func fromAlternativeName(_ alternativeName: String) throws -> Dipper {
-        guard let idx = Dipper.ALTERNATIVE_NAMES.firstIndex(of: alternativeName) else {
-            throw TymeError.invalidName(alternativeName)
-        }
-        return Dipper(index: idx)
-    }
-
-    /// Get next star
-    /// - Parameter n: Number of steps to advance
-    /// - Returns: Next Dipper instance
     public override func next(_ n: Int) -> Dipper {
-        return Dipper.fromIndex(nextIndex(n))
+        Dipper.fromIndex(nextIndex(n))
     }
-
-    /// Get steps to target index
-    /// - Parameter targetIndex: Target index
-    /// - Returns: Number of steps
-    public func stepsTo(_ targetIndex: Int) -> Int {
-        let c = Dipper.NAMES.count
-        var i = (targetIndex - index) % c
-        if i < 0 { i += c }
-        return i
-    }
-
-    // MARK: - Properties
-
-    public var alternativeName: String { Dipper.ALTERNATIVE_NAMES[index] }
-    public var westernName: String { Dipper.WESTERN_NAMES[index] }
-    public var position: String { Dipper.POSITIONS[index] }
-    public var brightnessRank: Int { Dipper.BRIGHTNESS_RANK[index] }
-    public var number: Int { index + 1 }
-
-    public var isBowl: Bool { Dipper.POSITIONS[index] == "斗魁" }
-    public var isHandle: Bool { Dipper.POSITIONS[index] == "斗柄" }
-
-    @available(*, deprecated, renamed: "alternativeName")
-    public func getAlternativeName() -> String { alternativeName }
-
-    @available(*, deprecated, renamed: "westernName")
-    public func getWesternName() -> String { westernName }
-
-    @available(*, deprecated, renamed: "position")
-    public func getPosition() -> String { position }
-
-    @available(*, deprecated, renamed: "brightnessRank")
-    public func getBrightnessRank() -> Int { brightnessRank }
-
-    @available(*, deprecated, renamed: "number")
-    public func getNumber() -> Int { number }
 }

--- a/Sources/tyme/star/NineDay.swift
+++ b/Sources/tyme/star/NineDay.swift
@@ -61,16 +61,6 @@ public final class NineDay: LoopTyme {
         return NineDay.fromIndex(nextIndex(n))
     }
 
-    /// Get steps to target index
-    /// - Parameter targetIndex: Target index
-    /// - Returns: Number of steps
-    public func stepsTo(_ targetIndex: Int) -> Int {
-        let c = NineDay.NAMES.count
-        var i = (targetIndex - index) % c
-        if i < 0 { i += c }
-        return i
-    }
-
     // MARK: - Properties
 
     public var number: Int { NineDay.NUMBERS[index] }

--- a/Sources/tyme/star/NineStar.swift
+++ b/Sources/tyme/star/NineStar.swift
@@ -83,16 +83,6 @@ public final class NineStar: LoopTyme {
         return NineStar.fromIndex(nextIndex(n))
     }
 
-    /// Get steps to target index
-    /// - Parameter targetIndex: Target index
-    /// - Returns: Number of steps
-    public func stepsTo(_ targetIndex: Int) -> Int {
-        let c = NineStar.NAMES.count
-        var i = (targetIndex - index) % c
-        if i < 0 { i += c }
-        return i
-    }
-
     // MARK: - Properties
 
     public var fullName: String { NineStar.FULL_NAMES[index] }


### PR DESCRIPTION
## Summary

- Add `size` computed property to `LoopTyme` base class (aligns with Java `getSize()`)
- Add `stepsTo(_ targetIndex: Int) -> Int` method to `LoopTyme` base class (aligns with Java `stepsTo(int)`)
- Remove duplicate `stepsTo` implementations from all 7 subclasses (Direction, Element, HeavenStem, EarthBranch, NineStar, NineDay, Dipper)
- Simplify `Dipper` to align with Java reference: expand from 7 to 9 stars (add 洞明, 隐元), remove non-Java properties (ALTERNATIVE_NAMES, WESTERN_NAMES, POSITIONS, BRIGHTNESS_RANK and related methods)

## Changes

| File | Change |
|------|--------|
| `Sources/tyme/core/LoopTyme.swift` | Add `size` property + `stepsTo()` method |
| `Sources/tyme/culture/Direction.swift` | Remove duplicate `stepsTo` |
| `Sources/tyme/culture/Element.swift` | Remove duplicate `stepsTo` |
| `Sources/tyme/sixtycycle/HeavenStem.swift` | Remove duplicate `stepsTo` |
| `Sources/tyme/sixtycycle/EarthBranch.swift` | Remove duplicate `stepsTo` |
| `Sources/tyme/star/Dipper.swift` | Expand to 9 stars, remove non-Java extras |
| `Sources/tyme/star/NineStar.swift` | Remove duplicate `stepsTo` |
| `Sources/tyme/star/NineDay.swift` | Remove duplicate `stepsTo` |

## Test plan

- [x] `swift build` — builds without errors
- [x] `swift test` — all 125 tests pass

Part of #88 (Phase 7 independent items: 7.5.1 LoopTyme base + 7.5.2 Dipper 9 stars)