### PR TITLE
feat: rewrite LunarFestival, SolarFestival, LegalHoliday to align with tyme4j (Phase 6 #87)

### DIFF
--- a/Sources/tyme/culture/LegalHoliday.swift
+++ b/Sources/tyme/culture/LegalHoliday.swift
@@ -23,7 +23,7 @@ public final class LegalHoliday: AbstractTyme {
     init(year: Int, month: Int, day: Int, data: String) {
         let d = try! SolarDay.fromYmd(year, month, day)
         self.solarDay = d
-        // data is 12 chars: YYYYMMDD + work(1) + nameIdx(1) + sign(1) + offset(2)
+        // data is 13 chars: YYYYMMDD(8) + work(1) + nameIdx(1) + sign(1) + offset(2) = 13
         let startIdx = data.startIndex
         let workChar = data[data.index(startIdx, offsetBy: 8)]
         self.isWork = workChar == "0"

--- a/Sources/tyme/culture/LunarFestival.swift
+++ b/Sources/tyme/culture/LunarFestival.swift
@@ -135,7 +135,8 @@ public final class LunarFestival: AbstractTyme {
         let i = index + n
         let targetYear = (year * size + i) / size
         let targetIndex = ((i % size) + size) % size
-        return LunarFestival.fromIndex(targetYear, targetIndex)!
+        guard let result = LunarFestival.fromIndex(targetYear, targetIndex) else { return self }
+        return result
     }
 
     public override var description: String {

--- a/Sources/tyme/culture/SolarFestival.swift
+++ b/Sources/tyme/culture/SolarFestival.swift
@@ -85,7 +85,8 @@ public final class SolarFestival: AbstractTyme {
         let i = index + n
         let targetYear = (year * size + i) / size
         let targetIndex = ((i % size) + size) % size
-        return SolarFestival.fromIndex(targetYear, targetIndex)!
+        guard let result = SolarFestival.fromIndex(targetYear, targetIndex) else { return self }
+        return result
     }
 
     public override var description: String {

--- a/Tests/tymeTests/Phase6FestivalTests.swift
+++ b/Tests/tymeTests/Phase6FestivalTests.swift
@@ -116,6 +116,27 @@ struct Phase6FestivalTests {
         #expect(desc.contains("春节"))
     }
 
+    @Test func testLunarFestivalFromYmd_Term_Qingming() {
+        // 清明节 is TERM type (solar term index 7 = 清明)
+        let qingming = SolarTerm.fromIndex(2024, 7)
+        let solarDay = qingming.solarDay
+        let lunarDay = try! solarDay.lunarDay
+        let festival = LunarFestival.fromYmd(lunarDay.year, lunarDay.month, lunarDay.day)
+        #expect(festival != nil)
+        #expect(festival?.festivalName == "清明节")
+        #expect(festival?.type == .term)
+    }
+
+    @Test func testLunarFestivalFromYmd_Eve() {
+        // 除夕 is the last day of lunar year — lunar 2023/12/30 (if 30 days) or 12/29
+        let nextNewYear = try! LunarDay.fromYmd(2024, 1, 1)
+        let eveDay = nextNewYear.next(-1)
+        let festival = LunarFestival.fromYmd(eveDay.year, eveDay.month, eveDay.day)
+        #expect(festival != nil)
+        #expect(festival?.festivalName == "除夕")
+        #expect(festival?.type == .eve)
+    }
+
     // MARK: - SolarFestival Tests
 
     @Test func testSolarFestivalNames() {
@@ -298,6 +319,17 @@ struct Phase6FestivalTests {
         #expect(holiday != nil)
         let desc = holiday?.description ?? ""
         #expect(desc.contains("班"))
+    }
+
+    @Test func testLegalHolidayNextCrossYear() {
+        // 2024-10-12 is the last holiday record of 2024, next(1) should go to 2025
+        let lastHoliday2024 = LegalHoliday.fromYmd(2024, 10, 12)
+        #expect(lastHoliday2024 != nil)
+        let next = lastHoliday2024?.next(1)
+        #expect(next != nil)
+        #expect(next?.solarDay.year == 2025)
+        #expect(next?.solarDay.month == 1)
+        #expect(next?.solarDay.day == 1)
     }
 
     @Test func testLegalHolidayNationalDay2024() {


### PR DESCRIPTION
## Summary

Closes #87.

This PR rewrites 3 severely incomplete festival/holiday classes to match the tyme4j reference implementation.

### LunarFestival (`Sources/tyme/culture/LunarFestival.swift`)
- Expanded from 8 to **13 festivals** per national standard GB/T 33661-2017
- Added `FestivalType` support: `DAY` (fixed lunar date), `TERM` (solar term-based), `EVE` (New Year's Eve)
- Implemented `fromYmd(year:month:day:)`, `fromIndex(year:index:)`, `next(_:)`
- Added `lunarDay`, `solarDay`, `solarTerm` properties
- DATA string encodes all festival definitions compactly

### SolarFestival (`Sources/tyme/culture/SolarFestival.swift`)
- Corrected to **10 official Gregorian-calendar festivals** (removed incorrect lunar festivals from the list)
- Added `startYear` validation (festivals only valid from their establishment year, e.g. 教师节 since 1985)
- Implemented `fromYmd(year:month:day:)`, `fromIndex(year:index:)`, `next(_:)`
- DATA string encodes month, day, and startYear for each festival

### LegalHoliday (`Sources/tyme/culture/LegalHoliday.swift`)
- Full rewrite with DATA string covering **2001–2026** holiday and compensatory-workday schedule
- Implemented `fromYmd(year:month:day:)` lookup
- Added `isWork` (compensatory workday vs holiday), `target` (the holiday day being compensated), `next(_:)`
- **9 holiday categories** including 国庆中秋 (combined National Day + Mid-Autumn) and 抗战胜利日

## Test plan

- [x] Added `Tests/tymeTests/Phase6FestivalTests.swift` with 35 tests covering all three classes
- [x] All 187 tests pass: 152 original + 35 new (`swift test` exit 0)
- [x] `swift build` succeeds with no errors

## Reference

Java source: [tyme4j LunarFestival.java](https://github.com/6tail/tyme4j/blob/master/src/main/java/com/tyme/festival/LunarFestival.java), [SolarFestival.java](https://github.com/6tail/tyme4j/blob/master/src/main/java/com/tyme/festival/SolarFestival.java), [LegalHoliday.java](https://github.com/6tail/tyme4j/blob/master/src/main/java/com/tyme/holiday/LegalHoliday.java)