### PR TITLE
feat: align Sixty/Twenty/Ten/Sound with tyme4j and add SixtyCycle methods

### DIFF
--- a/Sources/tyme/culture/Sixty.swift
+++ b/Sources/tyme/culture/Sixty.swift
@@ -1,19 +1,21 @@
 import Foundation
 
-/// 六十甲子 (Sixty Cycle)
-/// Extended attributes for the 60 SixtyCycle combinations
+/// 元（60年=1元）
+///
+/// Represents the three "Yuan" (元) periods: 上元 (Upper Yuan), 中元 (Middle Yuan), 下元 (Lower Yuan).
+/// One Yuan spans 60 years, and three Yuan form one complete cycle.
 public final class Sixty: LoopTyme {
-    /// Sixty names (六十甲子名称) - same as SixtyCycle
-    public static let NAMES = SixtyCycle.NAMES
+    /// Sixty names (三元名称)
+    public static let NAMES = ["上元", "中元", "下元"]
 
     /// Initialize with index
-    /// - Parameter index: Sixty index (0-59)
+    /// - Parameter index: Sixty index (0-2)
     public convenience init(index: Int) {
         self.init(names: Sixty.NAMES, index: index)
     }
 
     /// Initialize with name
-    /// - Parameter name: Sixty name (e.g., "甲子", "乙丑", etc.)
+    /// - Parameter name: Sixty name ("上元", "中元", or "下元")
     public convenience init(name: String) throws {
         try self.init(names: Sixty.NAMES, name: name)
     }
@@ -24,40 +26,23 @@ public final class Sixty: LoopTyme {
     }
 
     /// Get Sixty from index
-    /// - Parameter index: Sixty index (0-59)
+    /// - Parameter index: Sixty index (0-2)
     /// - Returns: Sixty instance
     public static func fromIndex(_ index: Int) -> Sixty {
         return Sixty(index: index)
     }
 
     /// Get Sixty from name
-    /// - Parameter name: Sixty name (e.g., "甲子", "乙丑", etc.)
+    /// - Parameter name: Sixty name ("上元", "中元", or "下元")
     /// - Returns: Sixty instance
     public static func fromName(_ name: String) throws -> Sixty {
         return try Sixty(name: name)
     }
 
-    /// Get next sixty
+    /// Get next Sixty
     /// - Parameter n: Number of steps to advance
     /// - Returns: Next Sixty instance
     public override func next(_ n: Int) -> Sixty {
         return Sixty.fromIndex(nextIndex(n))
     }
-
-    public var sixtyCycle: SixtyCycle { SixtyCycle.fromIndex(index) }
-    public var naYin: NaYin { NaYin.fromSixtyCycle(index) }
-    public var heavenStem: HeavenStem { HeavenStem.fromIndex(index % 10) }
-    public var earthBranch: EarthBranch { EarthBranch.fromIndex(index % 12) }
-
-    @available(*, deprecated, renamed: "sixtyCycle")
-    public func getSixtyCycle() -> SixtyCycle { sixtyCycle }
-
-    @available(*, deprecated, renamed: "naYin")
-    public func getNaYin() -> NaYin { naYin }
-
-    @available(*, deprecated, renamed: "heavenStem")
-    public func getHeavenStem() -> HeavenStem { heavenStem }
-
-    @available(*, deprecated, renamed: "earthBranch")
-    public func getEarthBranch() -> EarthBranch { earthBranch }
 }

--- a/Sources/tyme/culture/Sound.swift
+++ b/Sources/tyme/culture/Sound.swift
@@ -1,24 +1,42 @@
 import Foundation
 
-/// 五音 (Five Sounds)
-/// 宫、商、角、徵、羽 - The five tones in Chinese music theory
-/// Associated with Five Elements: 土、金、木、火、水
+/// 纳音 (Sound / NaYin Sound)
+///
+/// Represents the 30 NaYin (纳音) sound names associated with the 60 sexagenary cycle elements.
+/// Each pair of consecutive sexagenary cycle elements shares the same NaYin sound,
+/// yielding 30 distinct sounds in total.
+///
+/// Note: This corresponds to Java's `Sound` class, which represents 纳音 (not to be confused
+/// with the Five Sounds 五音 system of Chinese music theory).
 public final class Sound: LoopTyme {
-    /// Sound names (五音名称)
-    public static let NAMES = ["宫", "商", "角", "徵", "羽"]
+    /// Sound names (三十纳音名称)
+    public static let NAMES = [
+        "海中金", "炉中火", "大林木", "路旁土", "剑锋金",
+        "山头火", "涧下水", "城头土", "白蜡金", "杨柳木",
+        "泉中水", "屋上土", "霹雳火", "松柏木", "长流水",
+        "沙中金", "山下火", "平地木", "壁上土", "金箔金",
+        "覆灯火", "天河水", "大驿土", "钗钏金", "桑柘木",
+        "大溪水", "沙中土", "天上火", "石榴木", "大海水"
+    ]
 
-    /// WuXing (五行) mapping for sounds
-    /// 宫-土, 商-金, 角-木, 徵-火, 羽-水
-    private static let WU_XING = ["土", "金", "木", "火", "水"]
+    /// Five-element (五行) mapping for NaYin sounds
+    private static let WU_XING = [
+        "金", "火", "木", "土", "金",
+        "火", "水", "土", "金", "木",
+        "水", "土", "火", "木", "水",
+        "金", "火", "木", "土", "金",
+        "火", "水", "土", "金", "木",
+        "水", "土", "火", "木", "水"
+    ]
 
     /// Initialize with index
-    /// - Parameter index: Sound index (0-4)
+    /// - Parameter index: Sound index (0-29)
     public convenience init(index: Int) {
         self.init(names: Sound.NAMES, index: index)
     }
 
     /// Initialize with name
-    /// - Parameter name: Sound name (e.g., "宫", "商", etc.)
+    /// - Parameter name: Sound name (e.g., "海中金", "炉中火", etc.)
     public convenience init(name: String) throws {
         try self.init(names: Sound.NAMES, name: name)
     }
@@ -29,32 +47,29 @@ public final class Sound: LoopTyme {
     }
 
     /// Get Sound from index
-    /// - Parameter index: Sound index (0-4)
+    /// - Parameter index: Sound index (0-29)
     /// - Returns: Sound instance
     public static func fromIndex(_ index: Int) -> Sound {
         return Sound(index: index)
     }
 
     /// Get Sound from name
-    /// - Parameter name: Sound name (e.g., "宫", "商", etc.)
+    /// - Parameter name: Sound name (e.g., "海中金", "炉中火", etc.)
     /// - Returns: Sound instance
     public static func fromName(_ name: String) throws -> Sound {
         return try Sound(name: name)
     }
 
-    /// Get next sound
+    /// Get next Sound
     /// - Parameter n: Number of steps to advance
     /// - Returns: Next Sound instance
     public override func next(_ n: Int) -> Sound {
         return Sound.fromIndex(nextIndex(n))
     }
 
+    /// The Five-element (五行) name associated with this NaYin sound
     public var wuXing: String { Sound.WU_XING[index] }
+
+    /// The Element (五行) associated with this NaYin sound
     public var element: Element { try! Element.fromName(Sound.WU_XING[index]) }
-
-    @available(*, deprecated, renamed: "wuXing")
-    public func getWuXing() -> String { wuXing }
-
-    @available(*, deprecated, renamed: "element")
-    public func getElement() -> Element { element }
 }

--- a/Sources/tyme/culture/Ten.swift
+++ b/Sources/tyme/culture/Ten.swift
@@ -1,19 +1,23 @@
 import Foundation
 
-/// 十 (Ten)
-/// 十日 - The ten days of a traditional Chinese week (旬)
+/// 旬 (Ten-day period / Xun)
+///
+/// Represents the six "Xun" (旬) periods in the sexagenary cycle.
+/// Each Xun covers 10 consecutive sexagenary cycle elements starting from a "Jia" (甲) stem day.
+/// The six Xun are named after their starting sexagenary element:
+/// 甲子旬, 甲戌旬, 甲申旬, 甲午旬, 甲辰旬, 甲寅旬
 public final class Ten: LoopTyme {
-    /// Ten names (十日名称)
-    public static let NAMES = ["一", "二", "三", "四", "五", "六", "七", "八", "九", "十"]
+    /// Ten names (六旬名称)
+    public static let NAMES = ["甲子", "甲戌", "甲申", "甲午", "甲辰", "甲寅"]
 
     /// Initialize with index
-    /// - Parameter index: Ten index (0-9)
+    /// - Parameter index: Ten index (0-5)
     public convenience init(index: Int) {
         self.init(names: Ten.NAMES, index: index)
     }
 
     /// Initialize with name
-    /// - Parameter name: Ten name (e.g., "一", "二", etc.)
+    /// - Parameter name: Ten name (e.g., "甲子", "甲戌", etc.)
     public convenience init(name: String) throws {
         try self.init(names: Ten.NAMES, name: name)
     }
@@ -24,28 +28,23 @@ public final class Ten: LoopTyme {
     }
 
     /// Get Ten from index
-    /// - Parameter index: Ten index (0-9)
+    /// - Parameter index: Ten index (0-5)
     /// - Returns: Ten instance
     public static func fromIndex(_ index: Int) -> Ten {
         return Ten(index: index)
     }
 
     /// Get Ten from name
-    /// - Parameter name: Ten name (e.g., "一", "二", etc.)
+    /// - Parameter name: Ten name (e.g., "甲子", "甲戌", etc.)
     /// - Returns: Ten instance
     public static func fromName(_ name: String) throws -> Ten {
         return try Ten(name: name)
     }
 
-    /// Get next ten
+    /// Get next Ten
     /// - Parameter n: Number of steps to advance
     /// - Returns: Next Ten instance
     public override func next(_ n: Int) -> Ten {
         return Ten.fromIndex(nextIndex(n))
     }
-
-    public var dayNumber: Int { index + 1 }
-
-    @available(*, deprecated, renamed: "dayNumber")
-    public func getDayNumber() -> Int { dayNumber }
 }

--- a/Sources/tyme/culture/Twenty.swift
+++ b/Sources/tyme/culture/Twenty.swift
@@ -1,24 +1,21 @@
 import Foundation
 
-/// 二十 (Twenty)
-/// 二十日 - The twenty days of a lunar month
+/// 运（20年=1运，3运=1元）
+///
+/// Represents the nine "Yun" (运) periods within the traditional Chinese calendar cycle.
+/// One Yun spans 20 years, three Yun form one Yuan (元), and three Yuan form one complete cycle.
 public final class Twenty: LoopTyme {
-    /// Twenty names (二十日名称)
-    public static let NAMES = [
-        "初一", "初二", "初三", "初四", "初五",
-        "初六", "初七", "初八", "初九", "初十",
-        "十一", "十二", "十三", "十四", "十五",
-        "十六", "十七", "十八", "十九", "二十"
-    ]
+    /// Twenty names (九运名称)
+    public static let NAMES = ["一运", "二运", "三运", "四运", "五运", "六运", "七运", "八运", "九运"]
 
     /// Initialize with index
-    /// - Parameter index: Twenty index (0-19)
+    /// - Parameter index: Twenty index (0-8)
     public convenience init(index: Int) {
         self.init(names: Twenty.NAMES, index: index)
     }
 
     /// Initialize with name
-    /// - Parameter name: Twenty name (e.g., "初一", "初二", etc.)
+    /// - Parameter name: Twenty name (e.g., "一运", "二运", etc.)
     public convenience init(name: String) throws {
         try self.init(names: Twenty.NAMES, name: name)
     }
@@ -29,28 +26,28 @@ public final class Twenty: LoopTyme {
     }
 
     /// Get Twenty from index
-    /// - Parameter index: Twenty index (0-19)
+    /// - Parameter index: Twenty index (0-8)
     /// - Returns: Twenty instance
     public static func fromIndex(_ index: Int) -> Twenty {
         return Twenty(index: index)
     }
 
     /// Get Twenty from name
-    /// - Parameter name: Twenty name (e.g., "初一", "初二", etc.)
+    /// - Parameter name: Twenty name (e.g., "一运", "二运", etc.)
     /// - Returns: Twenty instance
     public static func fromName(_ name: String) throws -> Twenty {
         return try Twenty(name: name)
     }
 
-    /// Get next twenty
+    /// Get next Twenty
     /// - Parameter n: Number of steps to advance
     /// - Returns: Next Twenty instance
     public override func next(_ n: Int) -> Twenty {
         return Twenty.fromIndex(nextIndex(n))
     }
 
-    public var dayNumber: Int { index + 1 }
-
-    @available(*, deprecated, renamed: "dayNumber")
-    public func getDayNumber() -> Int { dayNumber }
+    /// The Yuan (元) this Yun belongs to (every 3 Yun = 1 Yuan)
+    public var sixty: Sixty {
+        Sixty.fromIndex(index / 3)
+    }
 }

--- a/Sources/tyme/sixtycycle/SixtyCycle.swift
+++ b/Sources/tyme/sixtycycle/SixtyCycle.swift
@@ -36,6 +36,27 @@ public final class SixtyCycle: LoopTyme {
         EarthBranch.fromIndex(index % EarthBranch.NAMES.count)
     }
 
+    /// 纳音 — the NaYin Sound for this sexagenary cycle element
+    public var sound: Sound {
+        Sound.fromIndex(index / 2)
+    }
+
+    /// 彭祖百忌 — Pengzu taboos for this sexagenary cycle element
+    public var pengZu: PengZu {
+        PengZu.fromSixtyCycle(self)
+    }
+
+    /// 旬 — the Ten-day period (Xun) this sexagenary element belongs to
+    public var ten: Ten {
+        Ten.fromIndex((heavenStem.index - earthBranch.index) / 2)
+    }
+
+    /// 旬空地支 — the two Empty Earth Branches (旬空) for this sexagenary element
+    public var extraEarthBranches: [EarthBranch] {
+        let first = EarthBranch.fromIndex(10 + earthBranch.index - heavenStem.index)
+        return [first, first.next(1)]
+    }
+
     public override func next(_ n: Int) -> SixtyCycle { SixtyCycle.fromIndex(nextIndex(n)) }
 
     @available(*, deprecated, renamed: "heavenStem")
@@ -43,6 +64,18 @@ public final class SixtyCycle: LoopTyme {
 
     @available(*, deprecated, renamed: "earthBranch")
     public func getEarthBranch() -> EarthBranch { earthBranch }
+
+    @available(*, deprecated, renamed: "sound")
+    public func getSound() -> Sound { sound }
+
+    @available(*, deprecated, renamed: "pengZu")
+    public func getPengZu() -> PengZu { pengZu }
+
+    @available(*, deprecated, renamed: "ten")
+    public func getTen() -> Ten { ten }
+
+    @available(*, deprecated, renamed: "extraEarthBranches")
+    public func getExtraEarthBranches() -> [EarthBranch] { extraEarthBranches }
 }
 
 extension SixtyCycle: Codable {

--- a/Tests/tymeTests/CultureTests.swift
+++ b/Tests/tymeTests/CultureTests.swift
@@ -507,9 +507,9 @@ import Testing
         #expect(nextAries.getName() == "白羊")
     }
     @Test func testSound() throws {
-        // Test all five sounds
-        let expectedNames = ["宫", "商", "角", "徵", "羽"]
-        let expectedWuXing = ["土", "金", "木", "火", "水"]
+        // Test first few NaYin sounds (纳音, 30 sounds)
+        let expectedNames = ["海中金", "炉中火", "大林木", "路旁土", "剑锋金"]
+        let expectedWuXing = ["金", "火", "木", "土", "金"]
         for i in 0..<5 {
             let sound = Sound.fromIndex(i)
             #expect(sound.getName() == expectedNames[i])
@@ -518,21 +518,21 @@ import Testing
         }
 
         // Test fromName
-        let gong = try Sound.fromName("宫")
-        #expect(gong.index == 0)
+        let haiZhongJin = try Sound.fromName("海中金")
+        #expect(haiZhongJin.index == 0)
 
         // Test next
-        let shang = gong.next(1)
-        #expect(shang.getName() == "商")
+        let luZhongHuo = haiZhongJin.next(1)
+        #expect(luZhongHuo.getName() == "炉中火")
 
-        // Test wrap around
-        let yu = Sound.fromIndex(4)
-        let nextGong = yu.next(1)
-        #expect(nextGong.getName() == "宫")
+        // Test wrap around (30 Sound)
+        let daHaiShui = Sound.fromIndex(29)
+        let nextHaiZhongJin = daHaiShui.next(1)
+        #expect(nextHaiZhongJin.getName() == "海中金")
 
         // Test element
-        let element = gong.element
-        #expect(element.getName() == "土")
+        let element = haiZhongJin.element
+        #expect(element.getName() == "金")
     }
     @Test func testPhase() throws {
         // Test all three phases
@@ -728,88 +728,78 @@ import Testing
         #expect(element.getName() == "金")
     }
     @Test func testSixty() throws {
-        // Test first few Sixty
-        let expectedNames = ["甲子", "乙丑", "丙寅", "丁卯", "戊辰"]
-        for i in 0..<5 {
+        // Test all three Yuan (三元)
+        let expectedNames = ["上元", "中元", "下元"]
+        for i in 0..<3 {
             let sixty = Sixty.fromIndex(i)
             #expect(sixty.getName() == expectedNames[i])
             #expect(sixty.index == i)
         }
 
         // Test fromName
-        let jiaZi = try Sixty.fromName("甲子")
-        #expect(jiaZi.index == 0)
+        let shangYuan = try Sixty.fromName("上元")
+        #expect(shangYuan.index == 0)
 
         // Test next
-        let yiChou = jiaZi.next(1)
-        #expect(yiChou.getName() == "乙丑")
+        let zhongYuan = shangYuan.next(1)
+        #expect(zhongYuan.getName() == "中元")
 
-        // Test wrap around (60 Sixty)
-        let guiHai = Sixty.fromIndex(59)
-        let nextJiaZi = guiHai.next(1)
-        #expect(nextJiaZi.getName() == "甲子")
-
-        // Test sixtyCycle
-        let sixtyCycle = jiaZi.sixtyCycle
-        #expect(sixtyCycle.getName() == "甲子")
-
-        // Test naYin
-        let naYin = jiaZi.naYin
-        #expect(naYin.getName() == "海中金")
-
-        // Test heavenStem
-        let heavenStem = jiaZi.heavenStem
-        #expect(heavenStem.getName() == "甲")
-
-        // Test earthBranch
-        let earthBranch = jiaZi.earthBranch
-        #expect(earthBranch.getName() == "子")
+        // Test wrap around (3 Sixty)
+        let xiaYuan = Sixty.fromIndex(2)
+        let nextShangYuan = xiaYuan.next(1)
+        #expect(nextShangYuan.getName() == "上元")
     }
     @Test func testTen() throws {
-        // Test all ten
-        let expectedNames = ["一", "二", "三", "四", "五", "六", "七", "八", "九", "十"]
-        for i in 0..<10 {
+        // Test all six Xun (六旬)
+        let expectedNames = ["甲子", "甲戌", "甲申", "甲午", "甲辰", "甲寅"]
+        for i in 0..<6 {
             let ten = Ten.fromIndex(i)
             #expect(ten.getName() == expectedNames[i])
             #expect(ten.index == i)
-            #expect(ten.dayNumber == i + 1)
         }
 
         // Test fromName
-        let yi = try Ten.fromName("一")
-        #expect(yi.index == 0)
+        let jiaZi = try Ten.fromName("甲子")
+        #expect(jiaZi.index == 0)
 
         // Test next
-        let er = yi.next(1)
-        #expect(er.getName() == "二")
+        let jiaXu = jiaZi.next(1)
+        #expect(jiaXu.getName() == "甲戌")
 
-        // Test wrap around
-        let shi = Ten.fromIndex(9)
-        let nextYi = shi.next(1)
-        #expect(nextYi.getName() == "一")
+        // Test wrap around (6 Ten)
+        let jiaYin = Ten.fromIndex(5)
+        let nextJiaZi = jiaYin.next(1)
+        #expect(nextJiaZi.getName() == "甲子")
     }
     @Test func testTwenty() throws {
-        // Test first few twenty
-        let expectedNames = ["初一", "初二", "初三", "初四", "初五"]
-        for i in 0..<5 {
+        // Test all nine Yun (九运)
+        let expectedNames = ["一运", "二运", "三运", "四运", "五运", "六运", "七运", "八运", "九运"]
+        for i in 0..<9 {
             let twenty = Twenty.fromIndex(i)
             #expect(twenty.getName() == expectedNames[i])
             #expect(twenty.index == i)
-            #expect(twenty.dayNumber == i + 1)
         }
 
         // Test fromName
-        let chuYi = try Twenty.fromName("初一")
-        #expect(chuYi.index == 0)
+        let yiYun = try Twenty.fromName("一运")
+        #expect(yiYun.index == 0)
 
         // Test next
-        let chuEr = chuYi.next(1)
-        #expect(chuEr.getName() == "初二")
+        let erYun = yiYun.next(1)
+        #expect(erYun.getName() == "二运")
 
-        // Test wrap around (20 Twenty)
-        let erShi = Twenty.fromIndex(19)
-        let nextChuYi = erShi.next(1)
-        #expect(nextChuYi.getName() == "初一")
+        // Test wrap around (9 Twenty)
+        let jiuYun = Twenty.fromIndex(8)
+        let nextYiYun = jiuYun.next(1)
+        #expect(nextYiYun.getName() == "一运")
+
+        // Test sixty (元)
+        let shangYuan = yiYun.sixty
+        #expect(shangYuan.getName() == "上元")
+        let wuYun = Twenty.fromIndex(4)
+        #expect(wuYun.sixty.getName() == "中元")
+        let jiuYun2 = Twenty.fromIndex(8)
+        #expect(jiuYun2.sixty.getName() == "下元")
     }
     @Test func testYinYang() throws {
         // Test Yang

--- a/Tests/tymeTests/Phase2AlignmentTests.swift
+++ b/Tests/tymeTests/Phase2AlignmentTests.swift
@@ -1,0 +1,250 @@
+import Testing
+@testable import tyme
+
+/// Phase 2 alignment tests: verifies that Sixty, Twenty, Ten, Sound, and SixtyCycle
+/// conform to the Java tyme4j reference implementation semantics.
+@Suite struct Phase2AlignmentTests {
+
+    // MARK: - Sixty (三元)
+
+    @Test func testSixtyNames() {
+        let expectedNames = ["上元", "中元", "下元"]
+        for i in 0..<3 {
+            let sixty = Sixty.fromIndex(i)
+            #expect(sixty.getName() == expectedNames[i])
+            #expect(sixty.index == i)
+        }
+    }
+
+    @Test func testSixtyFromName() throws {
+        let shangYuan = try Sixty.fromName("上元")
+        #expect(shangYuan.index == 0)
+
+        let zhongYuan = try Sixty.fromName("中元")
+        #expect(zhongYuan.index == 1)
+
+        let xiaYuan = try Sixty.fromName("下元")
+        #expect(xiaYuan.index == 2)
+    }
+
+    @Test func testSixtyNext() {
+        let shangYuan = Sixty.fromIndex(0)
+        #expect(shangYuan.next(1).getName() == "中元")
+        #expect(shangYuan.next(2).getName() == "下元")
+        // Wrap around
+        #expect(shangYuan.next(3).getName() == "上元")
+        #expect(Sixty.fromIndex(2).next(1).getName() == "上元")
+    }
+
+    @Test func testSixtyCount() {
+        // Sixty has exactly 3 entries
+        #expect(Sixty.NAMES.count == 3)
+    }
+
+    // MARK: - Twenty (九运)
+
+    @Test func testTwentyNames() {
+        let expectedNames = ["一运", "二运", "三运", "四运", "五运", "六运", "七运", "八运", "九运"]
+        for i in 0..<9 {
+            let twenty = Twenty.fromIndex(i)
+            #expect(twenty.getName() == expectedNames[i])
+            #expect(twenty.index == i)
+        }
+    }
+
+    @Test func testTwentyFromName() throws {
+        let yiYun = try Twenty.fromName("一运")
+        #expect(yiYun.index == 0)
+
+        let jiuYun = try Twenty.fromName("九运")
+        #expect(jiuYun.index == 8)
+    }
+
+    @Test func testTwentyNext() {
+        let yiYun = Twenty.fromIndex(0)
+        #expect(yiYun.next(1).getName() == "二运")
+        // Wrap around
+        #expect(Twenty.fromIndex(8).next(1).getName() == "一运")
+    }
+
+    @Test func testTwentySixty() {
+        // 一运(0), 二运(1), 三运(2) → 上元(0)
+        #expect(Twenty.fromIndex(0).sixty.getName() == "上元")
+        #expect(Twenty.fromIndex(1).sixty.getName() == "上元")
+        #expect(Twenty.fromIndex(2).sixty.getName() == "上元")
+        // 四运(3), 五运(4), 六运(5) → 中元(1)
+        #expect(Twenty.fromIndex(3).sixty.getName() == "中元")
+        #expect(Twenty.fromIndex(4).sixty.getName() == "中元")
+        #expect(Twenty.fromIndex(5).sixty.getName() == "中元")
+        // 七运(6), 八运(7), 九运(8) → 下元(2)
+        #expect(Twenty.fromIndex(6).sixty.getName() == "下元")
+        #expect(Twenty.fromIndex(7).sixty.getName() == "下元")
+        #expect(Twenty.fromIndex(8).sixty.getName() == "下元")
+    }
+
+    @Test func testTwentyCount() {
+        // Twenty has exactly 9 entries
+        #expect(Twenty.NAMES.count == 9)
+    }
+
+    // MARK: - Ten (六旬)
+
+    @Test func testTenNames() {
+        let expectedNames = ["甲子", "甲戌", "甲申", "甲午", "甲辰", "甲寅"]
+        for i in 0..<6 {
+            let ten = Ten.fromIndex(i)
+            #expect(ten.getName() == expectedNames[i])
+            #expect(ten.index == i)
+        }
+    }
+
+    @Test func testTenFromName() throws {
+        let jiaZi = try Ten.fromName("甲子")
+        #expect(jiaZi.index == 0)
+
+        let jiaXu = try Ten.fromName("甲戌")
+        #expect(jiaXu.index == 1)
+
+        let jiaYin = try Ten.fromName("甲寅")
+        #expect(jiaYin.index == 5)
+    }
+
+    @Test func testTenNext() {
+        let jiaZi = Ten.fromIndex(0)
+        #expect(jiaZi.next(1).getName() == "甲戌")
+        // Wrap around
+        #expect(Ten.fromIndex(5).next(1).getName() == "甲子")
+    }
+
+    @Test func testTenCount() {
+        // Ten has exactly 6 entries
+        #expect(Ten.NAMES.count == 6)
+    }
+
+    // MARK: - Sound (纳音, 30 names)
+
+    @Test func testSoundNames() {
+        let expectedFirstFive = ["海中金", "炉中火", "大林木", "路旁土", "剑锋金"]
+        for i in 0..<5 {
+            let sound = Sound.fromIndex(i)
+            #expect(sound.getName() == expectedFirstFive[i])
+            #expect(sound.index == i)
+        }
+    }
+
+    @Test func testSoundAllNames() {
+        let allNames = ["海中金", "炉中火", "大林木", "路旁土", "剑锋金",
+                        "山头火", "涧下水", "城头土", "白蜡金", "杨柳木",
+                        "泉中水", "屋上土", "霹雳火", "松柏木", "长流水",
+                        "沙中金", "山下火", "平地木", "壁上土", "金箔金",
+                        "覆灯火", "天河水", "大驿土", "钗钏金", "桑柘木",
+                        "大溪水", "沙中土", "天上火", "石榴木", "大海水"]
+        #expect(Sound.NAMES == allNames)
+        #expect(Sound.NAMES.count == 30)
+    }
+
+    @Test func testSoundFromName() throws {
+        let haiZhongJin = try Sound.fromName("海中金")
+        #expect(haiZhongJin.index == 0)
+
+        let daHaiShui = try Sound.fromName("大海水")
+        #expect(daHaiShui.index == 29)
+    }
+
+    @Test func testSoundNext() {
+        let haiZhongJin = Sound.fromIndex(0)
+        #expect(haiZhongJin.next(1).getName() == "炉中火")
+        // Wrap around
+        #expect(Sound.fromIndex(29).next(1).getName() == "海中金")
+    }
+
+    @Test func testSoundElement() {
+        // 海中金 → 金
+        #expect(Sound.fromIndex(0).element.getName() == "金")
+        // 炉中火 → 火
+        #expect(Sound.fromIndex(1).element.getName() == "火")
+        // 大林木 → 木
+        #expect(Sound.fromIndex(2).element.getName() == "木")
+        // 路旁土 → 土
+        #expect(Sound.fromIndex(3).element.getName() == "土")
+    }
+
+    @Test func testSoundWuXing() {
+        #expect(Sound.fromIndex(0).wuXing == "金")
+        #expect(Sound.fromIndex(1).wuXing == "火")
+        #expect(Sound.fromIndex(29).wuXing == "水")
+    }
+
+    // MARK: - SixtyCycle new methods
+
+    @Test func testSixtyCycleSound() {
+        // 甲子(0) and 乙丑(1) share the same NaYin: 海中金(0)
+        let jiaZi = SixtyCycle.fromIndex(0)
+        let yiChou = SixtyCycle.fromIndex(1)
+        #expect(jiaZi.sound.getName() == "海中金")
+        #expect(yiChou.sound.getName() == "海中金")
+
+        // 丙寅(2) and 丁卯(3) share: 炉中火(1)
+        #expect(SixtyCycle.fromIndex(2).sound.getName() == "炉中火")
+        #expect(SixtyCycle.fromIndex(3).sound.getName() == "炉中火")
+
+        // 癸亥(59) → 大海水(29)
+        #expect(SixtyCycle.fromIndex(59).sound.getName() == "大海水")
+    }
+
+    @Test func testSixtyCyclePengZu() {
+        // 甲子 → PengZu should have heaven stem and earth branch taboos
+        let jiaZi = SixtyCycle.fromIndex(0)
+        let pengZu = jiaZi.pengZu
+        #expect(pengZu.pengZuHeavenStem.getName().contains("甲"))
+        #expect(pengZu.pengZuEarthBranch.getName().contains("子"))
+    }
+
+    @Test func testSixtyCycleTen() {
+        // 甲子(0): heavenStem=甲(0), earthBranch=子(0)
+        // ten index = (0 - 0) / 2 = 0 → 甲子旬
+        let jiaZi = SixtyCycle.fromIndex(0)
+        #expect(jiaZi.ten.getName() == "甲子")
+
+        // 甲戌(10): heavenStem=甲(0), earthBranch=戌(10)
+        // ten index = (0 - 10) / 2 = -5 → mod 6 = 1 → 甲戌旬
+        let jiaXu = SixtyCycle.fromIndex(10)
+        #expect(jiaXu.ten.getName() == "甲戌")
+
+        // 乙亥(11): heavenStem=乙(1), earthBranch=亥(11)
+        // ten index = (1 - 11) / 2 = -5 → mod 6 = 1 → 甲戌旬
+        let yiHai = SixtyCycle.fromIndex(11)
+        #expect(yiHai.ten.getName() == "甲戌")
+    }
+
+    @Test func testSixtyCycleExtraEarthBranches() {
+        // 甲子旬 (甲子, index 0): heavenStem=甲(0), earthBranch=子(0)
+        // first = EarthBranch.fromIndex(10 + 0 - 0) = 戌(10)
+        // second = 戌.next(1) = 亥(11)
+        let jiaZi = SixtyCycle.fromIndex(0)
+        let extras = jiaZi.extraEarthBranches
+        #expect(extras.count == 2)
+        #expect(extras[0].getName() == "戌")
+        #expect(extras[1].getName() == "亥")
+    }
+
+    @Test func testSixtyCycleSoundMatchesNaYin() {
+        // Sound index for SixtyCycle = index / 2
+        // This should match NaYin which uses fromSixtyCycle(index / 2)
+        for i in 0..<60 {
+            let sc = SixtyCycle.fromIndex(i)
+            let sound = sc.sound
+            let naYin = NaYin.fromSixtyCycle(i)
+            #expect(sound.getName() == naYin.getName(),
+                    "SixtyCycle index \(i): sound '\(sound.getName())' should match NaYin '\(naYin.getName())'")
+        }
+    }
+
+    @Test func testSixtyCyclePengZuMatchesExistingFactory() {
+        // SixtyCycle.pengZu should produce same result as PengZu.fromSixtyCycle
+        let sc = SixtyCycle.fromIndex(0) // 甲子
+        let pengZuViaProperty = sc.pengZu
+        let pengZuViaFactory = PengZu.fromSixtyCycle(sc)
+        #expect(pengZuViaProperty.getName() == pengZuViaFactory.getName())
+    }
+}


### PR DESCRIPTION
## Summary

- **Sixty** (三元): rewrites the class from a 60-name wrapper over SixtyCycle to the correct 3-name Yuan cycle (`上元`/`中元`/`下元`) matching Java `Sixty.java`
- **Twenty** (九运): rewrites from 20 lunar-day ordinals to the 9 Yun periods (`一运`...`九运`); adds `var sixty: Sixty` to return the Yuan this Yun belongs to
- **Ten** (六旬): rewrites from ordinal 1-10 to the 6 Xun periods (`甲子`/`甲戌`/`甲申`/`甲午`/`甲辰`/`甲寅`) matching Java `Ten.java`
- **Sound** (纳音): rewrites from the 5-element 五音 system (`宫商角徵羽`) to the 30-name NaYin system matching Java `Sound.java`; retains `wuXing` and `element` properties
- **SixtyCycle**: adds `sound`, `pengZu`, `ten`, `extraEarthBranches` computed properties (with deprecated wrappers) matching Java `SixtyCycle.java`

## Test plan

- [ ] `swift build` compiles without errors
- [ ] `swift test` passes all 177 tests (152 pre-existing + 25 new in `Phase2AlignmentTests.swift`)
- [ ] `testSoundElementUnaffected` regression test still passes (new Sound has `.element` property)
- [ ] `Phase2AlignmentTests` verifies all Java-aligned semantics: Yuan/Yun hierarchy, Xun names, NaYin names, SixtyCycle.sound/pengZu/ten/extraEarthBranches

Closes #83