### PR TITLE
docs: add Code Style guidelines to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,19 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Code Style
+
+- Use `struct` and `mutating func` for all code.
+- Use `OptionSet` for all bitwise operations.
+- Use `Int`/`Int64` for all numerical calculations. (avoid `Double` unless strictly necessary for Astronomy).
+- Use `Optional` for all possible failures.
+- Use `throw Error` for all possible failures.
+- Use `public final` for all concrete classes.
+- Use `open` for all base classes.
+- **NO FORCE UNWRAP (`!`)**. Use `guard let` or `throw`.
+- Naming: Use Swift "Term of Art" (e.g., `computed property` instead of `getFoo()`).
+
+
 ## Build & Test Commands
 
 ```bash


### PR DESCRIPTION
## Summary

Add Code Style guidelines section to CLAUDE.md to help Claude Code follow project conventions:

- `struct` + `mutating func` preferred
- `OptionSet` for bitwise operations
- `Int`/`Int64` for numerical calculations
- `Optional` and `throw Error` for failures
- `public final` for concrete classes, `open` for base classes
- **No force unwrap (`!`)** — use `guard let` or `throw`
- Swift "Term of Art" naming (computed properties over `getFoo()`)

## Test plan

- [x] Documentation-only change, no code changes
- [x] No CI impact