### PR TITLE
ci: require SwiftLint to pass before build-and-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
 
   build-and-test:
     name: Build and Test
+    needs: lint
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

Add `needs: lint` to `build-and-test` job so SwiftLint must pass before any build or test runs.

**Before:** SwiftLint and build-and-test run in parallel — SwiftLint failure does not block the build.

**After:** SwiftLint is a prerequisite gate — if SwiftLint fails, build-and-test is skipped entirely.

## Test plan

- [x] CI-only change, no source code changes
- [ ] Verify SwiftLint failures now block the build job in CI