### PR TITLE
feat: SolarTime.phenology + Phenology year alignment + P1 fix

### DIFF
--- a/Sources/tyme/solar/SolarDay.swift
+++ b/Sources/tyme/solar/SolarDay.swift
@@ -210,7 +210,7 @@ public final class SolarDay: DayUnit, Tyme {
         var idx = dayIdx / 5
         if idx > 2 { idx = 2 }
         let t = d.solarTerm
-        return PhenologyDay(phenology: Phenology.fromIndex(t.index * 3 + idx), dayIndex: dayIdx - idx * 5)
+        return PhenologyDay(phenology: Phenology.fromIndex(t.year, t.index * 3 + idx), dayIndex: dayIdx - idx * 5)
     }
 
     /// 物候

--- a/Sources/tyme/solar/SolarTime.swift
+++ b/Sources/tyme/solar/SolarTime.swift
@@ -104,8 +104,20 @@ public final class SolarTime: SecondUnit, Tyme {
     @available(*, deprecated, renamed: "term")
     public func getTerm() -> SolarTerm { term }
 
+    /// 物候（七十二候）
+    public var phenology: Phenology {
+        var p = solarDay.phenology
+        if isBefore(p.julianDay.solarTime) {
+            p = p.next(-1)
+        }
+        return p
+    }
+
     @available(*, deprecated, renamed: "sixtyCycleHour")
     public func getSixtyCycleHour() -> SixtyCycleHour { sixtyCycleHour }
+
+    @available(*, deprecated, renamed: "phenology")
+    public func getPhenology() -> Phenology { phenology }
 
     @available(*, deprecated, renamed: "phase")
     public func getPhase() -> Phase { phase }

--- a/Tests/tymeTests/LunarTests.swift
+++ b/Tests/tymeTests/LunarTests.swift
@@ -333,6 +333,10 @@ import Testing
         // 2024-4-22 00:00 → 宜["嫁娶","交易","开市","安床","祭祀","求财"]
         let r2 = try SolarTime.fromYmdHms(2024, 4, 22, 0, 0, 0).lunarHour.recommends
         #expect(r2.map { $0.getName() } == ["嫁娶", "交易", "开市", "安床", "祭祀", "求财"])
+
+        // tyme4j TabooTest test12: 2024-4-22 00:00 → 忌
+        let a2 = try SolarTime.fromYmdHms(2024, 4, 22, 0, 0, 0).lunarHour.avoids
+        #expect(a2.map { $0.getName() } == ["出行", "移徙", "赴任", "词讼", "祈福", "修造", "求嗣"])
     }
 
     @Test func testLunarHourMinorRen() throws {

--- a/Tests/tymeTests/SolarTests.swift
+++ b/Tests/tymeTests/SolarTests.swift
@@ -194,6 +194,24 @@ import Testing
         #expect(t2.phase.getName() == "残月")
     }
 
+    // MARK: - SolarTime.phenology
+
+    @Test func testSolarTimePhenology() throws {
+        // tyme4j PhenologyTest test4: 时刻边界测试
+        #expect(try SolarTime.fromYmdHms(2025, 12, 26, 20, 49, 38).phenology.getName() == "蚯蚓结")
+        #expect(try SolarTime.fromYmdHms(2025, 12, 26, 20, 49, 56).phenology.getName() == "麋角解")
+    }
+
+    @Test func testPhenologyJulianDay() throws {
+        // tyme4j PhenologyTest test2: Phenology.fromIndex(2026, 1) → julianDay → "2025年12月26日"
+        let p = Phenology.fromIndex(2026, 1)
+        #expect(p.getName() == "麋角解")
+        let jdSolarDay = p.julianDay.solarDay
+        #expect(jdSolarDay.year == 2025)
+        #expect(jdSolarDay.month == 12)
+        #expect(jdSolarDay.day == 26)
+    }
+
     // MARK: - SolarYear.isLeap
 
     @Test func testSolarYearIsLeap() throws {


### PR DESCRIPTION
## Summary
- **Phase 5.6**: Implement `SolarTime.phenology` with year-aware `Phenology` class aligned with tyme4j
- **P1 fix**: Add missing `avoids` assertion in `testLunarHourRecommendsAvoids`
- **NAMES alignment**: Fix 3 mismatches with tyme4j (`大雨行时`, `菊有黄花`, `闭塞而成冬`)

## Changes
- `Phenology.swift`: Add `year` field, `julianDay` property, `fromIndex(year, index)` factory, year-carrying `next(_:)`, fix 3 NAMES entries
- `SolarDay.swift`: Pass `SolarTerm.year` to `Phenology.fromIndex` in `phenologyDay`
- `SolarTime.swift`: Add `phenology` computed property with time boundary detection
- `LunarTests.swift`: Add `avoids` assertion (tyme4j TabooTest test12)
- `SolarTests.swift`: Add `testSolarTimePhenology` and `testPhenologyJulianDay` tests

## Test plan
- [ ] `swift build` passes
- [ ] `swift test` passes (all existing + 2 new phenology tests)
- [ ] CI green on both Ubuntu and macOS