### PR TITLE
feat: Phase 6d — RabByung tests migration, cleanup and bug fixes

### DIFF
--- a/Sources/tyme/rabbyung/RabByungDay.swift
+++ b/Sources/tyme/rabbyung/RabByungDay.swift
@@ -121,9 +121,12 @@ public final class RabByungDay: AbstractTyme {
         }
         var n = 0
         var cur = epochMonth
+        var iterations = 0
         while !(rabByungMonth.year == cur.year && rabByungMonth.monthWithLeap == cur.monthWithLeap) {
+            precondition(iterations < 1500, "RabByungDay.solarDay: unexpected infinite loop")
             n += cur.dayCount
             cur = cur.next(1)
+            iterations += 1
         }
         var t = day
         for d in cur.specialDays {
@@ -147,7 +150,7 @@ public final class RabByungDay: AbstractTyme {
     // MARK: - Navigation
 
     public override func next(_ n: Int) -> RabByungDay {
-        if n == 0 { return (try? RabByungDay.fromSolarDay(solarDay)) ?? self }
+        if n == 0 { return self }
         return (try? RabByungDay.fromSolarDay(solarDay.next(n))) ?? self
     }
 

--- a/Sources/tyme/rabbyung/RabByungElement.swift
+++ b/Sources/tyme/rabbyung/RabByungElement.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 /// 饶迥五行 (Rab-byung Element)
-/// Tibetan calendar element system using 铁 (iron) instead of 金 (metal)
+/// 藏历五行，用铁代替金
 public final class RabByungElement: AbstractCulture {
-    /// Element names in Tibetan calendar (金→铁)
+    /// 藏历五行名称（金→铁）
     public static let NAMES = ["木", "火", "土", "铁", "水"]
 
     /// Internal element (uses standard Element)

--- a/Sources/tyme/solar/SolarYear.swift
+++ b/Sources/tyme/solar/SolarYear.swift
@@ -10,7 +10,7 @@ public final class SolarYear: YearUnit, Tyme {
         try SolarYear(year: year)
     }
 
-    public func getName() -> String { String(format: "%04d", year) }
+    public func getName() -> String { "\(year)年" }
 
     public var monthCount: Int { 12 }
     public var dayCount: Int { year == 1582 ? 355 : SolarUtil.isLeapYear(year) ? 366 : 365 }


### PR DESCRIPTION
## Summary

- **缺陷修复**：`RabByungDay.next(0)` 改回 `return self`；`solarDay` while 循环加 precondition 迭代保护
- **测试移植**：对齐 tyme4j 全部 RabByungTest 测试用例（30 个测试，覆盖 Year/Month/Day）
- **Issue #108 测试补充**：错误路径（day=0/31/缺失日/非闰日）、next(0) 身份、dayWithLeap 符号、上界越界
- **BUG 修复**：SolarYear.getName() 对齐 tyme4j 返回 "%d年" 格式；testRabByungMonthNext 修正 2024 闰月年 next(13) 期望值
- **Tibetan 残留清理**：Sources 注释中 Tibetan → 中文说明

## Test plan

- [x] `swift build` 通过（0 error）
- [x] `swift test` RabByungTests 30/30 全部通过
- [x] QA 门禁验证通过