### PR TITLE
fix: add next(12) assertions for leap-month year in testRabByungMonthNext

### DIFF
--- a/Tests/tymeTests/RabByungTests.swift
+++ b/Tests/tymeTests/RabByungTests.swift
@@ -165,7 +165,9 @@ import Testing
         let m = try RabByungMonth.fromYm(2024, 1)
         #expect(m.next(1).getName() == "二月")
         #expect(m.next(1).year == 2024)
-        #expect(m.next(13).year == 2025)
+        #expect(m.next(12).year == 2024)        // 有闰月年：12步不跨年
+        #expect(m.next(12).getName() == "十二月")
+        #expect(m.next(13).year == 2025)        // 13步才跨年
         #expect(m.next(0).getName() == "正月")
     }
 


### PR DESCRIPTION
## Summary

- 补充 `testRabByungMonthNext` 中缺失的 `next(12)` 断言
- 2024 藏历年有闰六月（monthCount=13），`next(12)` 应停留在 2024 年
- 新增断言明确覆盖闰月年不提前跨年的边界行为

## Test plan

- [x] `swift test --filter RabByungTests/testRabByungMonthNext` — passed
- [x] `swift build` — 0 errors

Closes #106