### PR TITLE
refactor: tech-debt cleanup for Issues #125 #126 #128 #129 #131

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **NO FORCE UNWRAP (`!`)**. Use `guard let` or `throw`.
 - Naming: Use Swift "Term of Art" (e.g., `computed property` instead of `getFoo()`).
 
+## Error Handling
+
+- **Throwing methods**: Use `throw TymeError.*` for all validation failures. Never use `fatalError` or `preconditionFailure` in throwing contexts — these were systematically replaced in Phase 2 (Issue #32).
+- **Non-throwing overrides** (e.g., `next(_ n: Int) -> Self` from `AbstractTyme`): Cannot `throw`. Use explicit `guard let ... else { return self }` for expected out-of-range inputs (boundary behavior). Use `preconditionFailure("diagnostic message")` only for **internal invariant violations** (i.e., conditions that indicate a bug, not user input error).
+- **Consistency within a method**: Do not mix `return self` and `preconditionFailure` for the same class of failure in one method. Decide: is this a boundary (→ `return self`) or a bug (→ `preconditionFailure`)?
+
 ## Audit Commands (Orchestration)
 
 - **`/audit <pr_id>`**: 全量审计（包含 Simplifier）。

--- a/Sources/tyme/rabbyung/RabByungDay.swift
+++ b/Sources/tyme/rabbyung/RabByungDay.swift
@@ -84,7 +84,7 @@ public final class RabByungDay: AbstractTyme {
         let epochDay = try SolarDay.fromYmd(1951, 1, 8)
         var days = solarDay.subtract(epochDay)
         guard days >= 0 else {
-            throw TymeError.invalidDay(days)
+            throw TymeError.invalidYear(solarDay.year)
         }
         var m = try RabByungMonth.fromYm(1950, 12)
         var count = m.dayCount

--- a/Sources/tyme/rabbyung/RabByungMonth.swift
+++ b/Sources/tyme/rabbyung/RabByungMonth.swift
@@ -5,6 +5,10 @@ import Foundation
 /// 算法对齐 tyme4j com.tyme.rabbyung.RabByungMonth
 public final class RabByungMonth: AbstractTyme {
 
+    private static let minYear = 1950
+    private static let maxYear = 2050
+    private static let minYearFirstMonth = 12  // 1950 年仅支持从十二月起
+
     public static let NAMES = ["正月", "二月", "三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月", "十二月"]
     public static let ALIAS = ["神变月", "苦行月", "具香月", "萨嘎月", "作净月", "明净月", "具醉月", "具贤月", "天降月", "持众月", "庄严月", "满意月"]
 
@@ -56,11 +60,11 @@ public final class RabByungMonth: AbstractTyme {
             throw TymeError.invalidMonth(month)
         }
         let y = year.year
-        guard y >= 1950, y <= 2050 else {
+        guard y >= Self.minYear, y <= Self.maxYear else {
             throw TymeError.invalidYear(y)
         }
         let m = abs(month)
-        guard !(y == 1950 && m < 12) else {
+        guard !(y == Self.minYear && m < Self.minYearFirstMonth) else {
             throw TymeError.invalidMonth(month)
         }
         let leap = month < 0
@@ -171,9 +175,9 @@ public final class RabByungMonth: AbstractTyme {
             }
         }
         let targetYear = y.year
-        guard targetYear >= 1950, targetYear <= 2050,
+        guard targetYear >= Self.minYear, targetYear <= Self.maxYear,
               finalM >= 1, finalM <= 12,
-              !(targetYear == 1950 && finalM < 12) else {
+              !(targetYear == Self.minYear && finalM < Self.minYearFirstMonth) else {
             return self
         }
         // 闰月一致性由算法保证——若此处失败则为内部 bug

--- a/Sources/tyme/rabbyung/RabByungYear.swift
+++ b/Sources/tyme/rabbyung/RabByungYear.swift
@@ -52,8 +52,13 @@ public final class RabByungYear: AbstractTyme {
     /// 公历年
     public var year: Int { 1024 + rabByungIndex * 60 + sixtyCycle.index }
 
-    /// 藏历五行；index 始终在 0-4 范围内，nil 情况实际不可达
-    public var element: RabByungElement? { try? RabByungElement(index: sixtyCycle.heavenStem.element.index) }
+    /// 藏历五行；index 始终在 0-4 范围内
+    public var element: RabByungElement {
+        guard let e = try? RabByungElement(index: sixtyCycle.heavenStem.element.index) else {
+            preconditionFailure("RabByungYear.element: invariant violation index=\(sixtyCycle.heavenStem.element.index)")
+        }
+        return e
+    }
 
     /// 生肖
     public var zodiac: Zodiac { sixtyCycle.earthBranch.zodiac }
@@ -78,7 +83,7 @@ public final class RabByungYear: AbstractTyme {
         if s.hasPrefix("一十") {
             s = String(s.dropFirst())
         }
-        return "第\(s)饶迥\(element?.getName() ?? "")\(zodiac.getName())年"
+        return "第\(s)饶迥\(element.getName())\(zodiac.getName())年"
     }
 
     /// 闰月，0表示无闰月
@@ -124,7 +129,7 @@ public final class RabByungYear: AbstractTyme {
     public func getYear() -> Int { year }
 
     @available(*, deprecated, renamed: "element")
-    public func getElement() -> RabByungElement? { element }
+    public func getElement() -> RabByungElement { element }
 
     @available(*, deprecated, renamed: "zodiac")
     public func getZodiac() -> Zodiac { zodiac }


### PR DESCRIPTION
## Summary

This PR addresses five tech-debt issues in the RabByung module and CLAUDE.md:

- **Issue #125**: Add Error Handling section to CLAUDE.md clarifying throwing vs non-throwing contexts
- **Issue #126**: Extract magic numbers (1950, 2050, 12) to named constants in RabByungMonth
- **Issue #128**: Fix error type in RabByungDay.fromSolarDay() from invalidDay to invalidYear
- **Issue #129**: Remove unnecessary Optional from RabByungYear.element
- **Issue #131**: Audit remaining try? usage in rabbyung/ module (no additional issues found)

## Changes

### CLAUDE.md
- Added new **Error Handling** section explaining:
  - Throwing methods use `throw TymeError.*`
  - Non-throwing overrides use `guard let ... else { return self }` for boundaries
  - `preconditionFailure()` for internal invariant violations only

### RabByungMonth.swift
- Extracted private static constants: `minYear`, `maxYear`, `minYearFirstMonth`
- Replaced magic numbers in validation and navigation logic

### RabByungDay.swift
- Fixed fromSolarDay() to throw `invalidYear(solarDay.year)` instead of `invalidDay(days)`
- More accurate error semantics for out-of-range dates

### RabByungYear.swift
- Changed `element` from `RabByungElement?` to `RabByungElement`
- Updated getName() to use non-optional element
- Updated deprecated getElement() return type

## Test Results

- ✅ swift build (0 errors)
- ✅ swift test (355 tests passed)
- ✅ swiftlint (0 error-level violations)

## Checklist

- [x] Code compiles without errors
- [x] All tests pass
- [x] No new linter violations
- [x] Tech-debt issues addressed