### PR TITLE
test: add boundary and element coverage tests for Issues #137 #138

### DIFF
--- a/Tests/tymeTests/RabByungTests.swift
+++ b/Tests/tymeTests/RabByungTests.swift
@@ -492,16 +492,29 @@ import Testing
         #expect(leap.day == 16)
     }
 
-    // MARK: - RabByungYear：element 验证（Issue #133）
+    // MARK: - RabByungYear：element 验证（Issue #133 & #137）
 
     @Test func testRabByungYearElement() throws {
-        // 1027 年是第一饶迥火兔年
+        // 1027 年是第一饶迥火兔年（丁卯）
         let y1027 = try RabByungYear.fromYear(1027)
         #expect(y1027.element.name == "火")
 
         // 2024 年是木龙年（甲辰）
         let y2024 = try RabByungYear.fromYear(2024)
         #expect(y2024.element.name == "木")
+
+        // Issue #137：补全五种元素测试覆盖
+        // 1028 年是第一饶迥土龙年（戊辰）
+        let y1028 = try RabByungYear.fromYear(1028)
+        #expect(y1028.element.name == "土")
+
+        // 1030 年是第一饶迥铁马年（庚午）
+        let y1030 = try RabByungYear.fromYear(1030)
+        #expect(y1030.element.name == "铁")
+
+        // 1032 年是第一饶迥水猴年（壬申）
+        let y1032 = try RabByungYear.fromYear(1032)
+        #expect(y1032.element.name == "水")
     }
 
     // MARK: - RabByungDay：SolarDay 超出范围返回错误（Issue #133）
@@ -510,5 +523,20 @@ import Testing
         // 2051-03-01 超出 RabByungDay 支持范围（最后一天是 2051-02-11）
         let d = try SolarDay.fromYmd(2051, 3, 1)
         #expect(d.rabByungDay == nil)
+    }
+
+    // MARK: - RabByungDay：边界正向验证（Issue #138）
+
+    @Test func testRabByungDayFromSolarDayBoundary() throws {
+        // 支持范围最后一个有效日期：2051-02-11（藏历2050年十二月三十）
+        let lastSolarDay = try SolarDay.fromYmd(2051, 2, 11)
+        let rbd = try RabByungDay.fromSolarDay(lastSolarDay)
+
+        // 验证成功转换且返回有效值
+        #expect(rbd.rabByungMonth.year == 2050)
+        #expect(rbd.rabByungMonth.month == 12)
+        #expect(rbd.day == 30)
+        #expect(rbd.isLeap == false)
+        #expect(rbd.rabByungMonth.rabByungYear.getName() + rbd.rabByungMonth.getName() + rbd.getName() == "第十八饶迥铁马年十二月三十")
     }
 }


### PR DESCRIPTION
## Summary

补全藏历相关测试覆盖，完成 Issue #137 和 #138。

### Issue #137 - RabByungYear.element 五种元素测试覆盖

在 `testRabByungYearElement()` 中扩展测试，补充全部 5 种藏历五行元素：

- 木（木）：2024年（甲辰）✓ 已有
- 火（火）：1027年（丁卯）✓ 已有  
- 土（土）：1028年（戊辰）✓ 新增
- 铁（金）：1030年（庚午）✓ 新增
- 水（水）：1032年（壬申）✓ 新增

映射规则：天干五行元素 (index) → 藏历五行元素
- 甲乙 (0, 1) → 木 (0)
- 丙丁 (2, 3) → 火 (1)
- 戊己 (4, 5) → 土 (2)
- 庚辛 (6, 7) → 铁 (3)
- 壬癸 (8, 9) → 水 (4)

### Issue #138 - RabByungDay 边界正向验证测试

新增 `testRabByungDayFromSolarDayBoundary()` 测试，验证 RabByungDay 支持范围内最后一个有效日期：

- 日期：2051-02-11（公历）
- 对应：藏历 2050 年十二月三十
- 验证：`fromSolarDay()` 不抛异常，返回有效值

## Test Results

- ✅ `swift build`：编译成功
- ✅ `swift test`：359 个测试全部通过  
- ✅ `swiftlint`：0 个 error 级别违规

## 🤖 Generated with Claude Code