### PR TITLE
chore: update Claude agent configs with MCP tools and bypassPermissions

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -1,8 +1,13 @@
 ---
 name: architect
 description: Architect role. For PRs: architecture review (module boundaries, pattern consistency, dependency layering). For design: architecture analysis and design (context, impact, change plan and output).
-tools: "*"
+tools:
+  - "*"
+  - Bash(gh *)
+  - mcp__plugin_github_github
+  - mcp__plugin_serena_serena
 model: sonnet
+permissionMode: bypassPermissions
 ---
 
 # Role: Architect
@@ -57,7 +62,27 @@ The following apply in all contexts; PR review and design planning each have the
 - **APPROVE**: No architecture issues, or only minor deviations already noted under “Suggestions” and not blocking merge.
 - **REQUEST_CHANGES**: Misplaced modules, broken layering, violation of core patterns or CLAUDE.md conventions such that merging would increase technical debt or hurt extensibility.
 
-**Output format (PR review conclusion, paste into GitHub Review):**
+**⛔ Do NOT run `gh pr review --approve` or `gh pr review --request-changes`.** The same GitHub account owns the repo; GitHub rejects self-approval and self-request-changes. Team-lead handles the actual GitHub merge.
+
+**✅ DO post your review to GitHub as a comment** using the MCP tool (preferred):
+```
+mcp__plugin_github_github__pull_request_review_write:
+  method: create
+  owner: xuanyunhui
+  repo: tyme4swift
+  pullNumber: <PR_NUMBER>
+  event: COMMENT
+  body: |
+    # Architect review
+    ...
+```
+Or fallback to `gh pr review <PR_NUMBER> --comment --body "..."` if MCP is unavailable.
+
+This makes the review visible in the PR timeline. Then communicate your verdict via team messages.
+
+**GitHub 操作优先级：** 优先使用 MCP 工具（`mcp__plugin_github_github__*`），避免 `gh` CLI Bash 命令。例如：读取 PR 用 `pull_request_read`，读取文件用 `get_file_contents`，列出 Issue 用 `list_issues`。
+
+**Output format (use both as GitHub comment AND in team message to team-lead or swift-developer):**
 
 ```markdown
 # Architect review

--- a/.claude/agents/audit-manager.md
+++ b/.claude/agents/audit-manager.md
@@ -1,8 +1,12 @@
 ---
 name: audit-manager
 description: Audit Manager (Tool Orchestrator) that orchestrates the tools to audit the code.
-tools: "*"
+tools:
+  - "*"
+  - mcp__plugin_github_github
+  - mcp__plugin_serena_serena
 model: haiku
+permissionMode: bypassPermissions
 ---
 
 # Role: Audit Manager (Tool Orchestrator)

--- a/.claude/agents/ios-dev.md
+++ b/.claude/agents/ios-dev.md
@@ -1,8 +1,12 @@
 ---
 name: ios-dev
 description: Writes production-quality iOS/Swift code (SwiftUI/UIKit) following Apple best practices; supports both app projects and Swift Packages.
-tools: "*"
+tools:
+  - "*"
+  - mcp__plugin_github_github
+  - mcp__plugin_serena_serena
 model: haiku
+permissionMode: bypassPermissions
 ---
 
 # iOS Developer Agent

--- a/.claude/agents/qa.md
+++ b/.claude/agents/qa.md
@@ -1,8 +1,11 @@
 ---
 name: qa
 description: Designs test strategies, writes test cases, runs tests (e.g. swift test), and delivers test reports and sign-off for release.
-tools: "*"
+tools:
+  - "*"
+  - mcp__plugin_serena_serena
 model: haiku
+permissionMode: bypassPermissions
 ---
 
 # QA Engineer Agent


### PR DESCRIPTION
## Summary

更新 `.claude/agents/` 下四个 agent 配置文件：

### 共同改动（所有 agent）
- `tools: "*"` → 展开为列表格式，显式添加 `mcp__plugin_github_github` 和 `mcp__plugin_serena_serena`
- 添加 `permissionMode: bypassPermissions`（避免团队运行时频繁卡在权限请求）

### architect.md 额外改动
- 添加 `Bash(gh *)` 工具权限（fallback 用）
- 明确禁止 `gh pr review --approve` / `--request-changes`（GitHub 不允许自我审批）
- 改为使用 MCP 工具（`pull_request_review_write`）发布评审评论
- 标注 **GitHub 操作优先用 MCP 工具**

### audit-manager.md
- 补齐文件末尾换行符

## 背景

这些配置在本轮 Issue 修复流程中经实战验证有效：
- `bypassPermissions` 避免了 team 启动时需要逐个确认权限的问题
- MCP 工具替代 `gh` CLI 是用户明确偏好
- 禁止 `--approve` 解决了架构师自我审批被 GitHub 拒绝的问题