### PR TITLE
fix: remove conflicting Bash(gh *) from architect agent tools config

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -3,7 +3,6 @@ name: architect
 description: Architect role. For PRs: architecture review (module boundaries, pattern consistency, dependency layering). For design: architecture analysis and design (context, impact, change plan and output).
 tools:
   - "*"
-  - Bash(gh *)
   - mcp__plugin_github_github
   - mcp__plugin_serena_serena
 model: sonnet


### PR DESCRIPTION
## Summary

- 修复 `architect` 自定义 agent 无法被 Task 工具加载的问题
- 原因：`tools` 列表中同时有 `"*"`（全权限）和 `Bash(gh *)`（受限 Bash），组合导致 YAML 解析失败
- 修复：删除冗余的 `Bash(gh *)` 条目，保留 `"*"` 即可

## Test plan

- [ ] 验证 architect agent 可被正常加载（在下次团队任务中观察）

🤖 Generated with [Claude Code](https://claude.com/claude-code)