### PR TITLE
feat(validation): enhance fixture validation with empty array check and semantic error

### DIFF
--- a/Tests/tymeTests/ValidationTests.swift
+++ b/Tests/tymeTests/ValidationTests.swift
@@ -80,7 +80,7 @@ struct NineDayCase: Decodable {
 func loadFixture<T: Decodable>(_ name: String, type: T.Type) throws -> [T] {
     guard let url = Bundle.module.url(
         forResource: name, withExtension: "json", subdirectory: "Fixtures") else {
-        throw TymeError.invalidDay(0)
+        throw CocoaError(.fileNoSuchFile)
     }
     let data = try Data(contentsOf: url)
     return try JSONDecoder().decode([T].self, from: data)
@@ -91,7 +91,11 @@ func loadFixture<T: Decodable>(_ name: String, type: T.Type) throws -> [T] {
 // not a runtime user error — preconditionFailure is appropriate per CLAUDE.md.
 func requireFixture<T: Decodable>(_ name: String, type: T.Type) -> [T] {
     do {
-        return try loadFixture(name, type: type)
+        let result = try loadFixture(name, type: type)
+        if result.isEmpty {
+            preconditionFailure("\(name).json fixture is empty — check generation script")
+        }
+        return result
     } catch {
         preconditionFailure("Failed to load \(name).json fixture: \(error)")
     }


### PR DESCRIPTION
## Summary

This PR enhances fixture loading validation in ValidationTests with two complementary improvements:

- **Issue #159**: Add empty array validation to `requireFixture()` helper
- **Issue #160**: Replace `TymeError.invalidDay(0)` with `CocoaError(.fileNoSuchFile)` for semantic accuracy

## Changes

### Issue #159 - Empty Array Validation
Add validation in `requireFixture<T>()` to detect empty fixture files:
```swift
if result.isEmpty {
    preconditionFailure("\(name).json fixture is empty — check generation script")
}
```
This guards against broken fixture generation scripts that may produce empty JSON arrays, which would mask issues during test initialization.

### Issue #160 - Semantic Error Handling
Replace incorrect error type in `loadFixture<T>()`:
- **Before**: `throw TymeError.invalidDay(0)` (business logic error)
- **After**: `throw CocoaError(.fileNoSuchFile)` (file system error)

`CocoaError(.fileNoSuchFile)` is semantically correct because:
- Missing fixture files are file system/build configuration issues, not business logic errors
- `TymeError` is reserved for calendar/date computation failures
- Aligns with error handling best practices

## Testing

✅ All ValidationTests pass (11 suites, ~25K parameterized cases)
- swift build: success
- swift test --filter ValidationTests: 11 suites passed, 92.987 seconds

## Related Issues

Closes #159, #160